### PR TITLE
feat: build-time fetch of official skill-creator guide

### DIFF
--- a/.optimus/skills/skill-checker/SKILL.md
+++ b/.optimus/skills/skill-checker/SKILL.md
@@ -12,14 +12,11 @@ It checks file paths, naming conventions, MCP tool accuracy, and structural comp
 
 <instructions>
 
-## Step 1: Use the Official Skill Creator
+## Step 1: Reference the Official Skill Creator Methodology
 
-Invoke the official Claude Code `skill-creator` plugin to generate a high-quality skill:
-- Use `/skill-creator` in Create mode
-- Describe what the skill should teach (e.g., "Create a skill that teaches agents how to run database migrations")
-- The plugin will guide you through requirements gathering and generate a well-structured skill file
+Read the official guide at `.optimus/skills/skill-checker/official-guide.md` for the latest Claude skill-creator methodology (4 modes: Create, Eval, Improve, Benchmark). The guide is auto-fetched during builds and describes the recommended workflow including the 4 composable agents (Executor, Grader, Comparator, Analyzer).
 
-If the official plugin is not available, write the skill manually following the template in Step 3.
+If the guide file is not available, write the skill manually following the template in Step 3.
 
 ## Step 2: Apply Optimus Registration Rules
 
@@ -36,7 +33,7 @@ Before saving, ensure the generated skill complies with these project-specific r
 
 ## Step 3: Manual Template (Fallback)
 
-If the official `/skill-creator` plugin is unavailable, use this minimal template:
+If the official guide is unavailable, use this minimal template:
 
 <template>
 ---

--- a/optimus-plugin/scripts/fetch-skill-creator-guide.js
+++ b/optimus-plugin/scripts/fetch-skill-creator-guide.js
@@ -1,0 +1,116 @@
+/**
+ * fetch-skill-creator-guide.js
+ *
+ * Pre-build script that fetches the official Claude skill-creator plugin page
+ * and saves a reference guide to optimus-plugin/skills/skill-checker/official-guide.md.
+ *
+ * If the fetch fails (network error, 403, etc.), the build continues — the
+ * existing file (if any) is left untouched.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SOURCE_URL = 'https://claude.com/plugins/skill-creator';
+const OUTPUT_PATH = path.resolve(__dirname, '..', 'skills', 'skill-checker', 'official-guide.md');
+
+/**
+ * Minimal HTML-to-text extraction.
+ * Strips tags, decodes common entities, and collapses whitespace.
+ */
+function htmlToText(html) {
+  // Remove script/style blocks
+  let text = html.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, '');
+  // Convert <br> and block-level closers to newlines
+  text = text.replace(/<br\s*\/?>/gi, '\n');
+  text = text.replace(/<\/(p|div|h[1-6]|li|tr)>/gi, '\n');
+  // Strip remaining tags
+  text = text.replace(/<[^>]+>/g, '');
+  // Decode common entities
+  text = text.replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+  // Collapse runs of whitespace (preserve newlines)
+  text = text.replace(/[ \t]+/g, ' ');
+  text = text.replace(/\n[ \t]+/g, '\n');
+  text = text.replace(/\n{3,}/g, '\n\n');
+  return text.trim();
+}
+
+/**
+ * Extract only the plugin description section from the full page text.
+ * The page has navigation/footer noise — we want the content between
+ * "Skill Creator" heading and "Related plugins".
+ */
+function extractPluginContent(fullText) {
+  // Find the main content block: starts after "Skill Creator\nCreate, improve"
+  const startMatch = fullText.match(/Skill Creator\nCreate, improve/);
+  if (!startMatch) return null;
+
+  const startIdx = startMatch.index;
+
+  // End at "Related plugins" or "Homepage" footer markers
+  const endMarkers = ['Related plugins', 'HomepageHomepage'];
+  let endIdx = fullText.length;
+  for (const marker of endMarkers) {
+    const idx = fullText.indexOf(marker, startIdx);
+    if (idx !== -1 && idx < endIdx) endIdx = idx;
+  }
+
+  return fullText.substring(startIdx, endIdx).trim();
+}
+
+async function fetchGuide() {
+  const fetchDate = new Date().toISOString().split('T')[0];
+
+  console.log(`[fetch-skill-creator-guide] Fetching ${SOURCE_URL} ...`);
+
+  const res = await fetch(SOURCE_URL, {
+    headers: { 'User-Agent': 'optimus-build/1.0' },
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  }
+
+  const html = await res.text();
+  const fullText = htmlToText(html);
+  const body = extractPluginContent(fullText);
+
+  if (!body || body.length < 100) {
+    throw new Error('Extracted content too short — page may have changed structure');
+  }
+
+  const markdown = [
+    '# Official Claude Skill Creator Guide',
+    '',
+    `> Auto-fetched from ${SOURCE_URL} on ${fetchDate}.`,
+    '> This file is regenerated on each build. Do not edit manually.',
+    '',
+    body,
+    '',
+  ].join('\n');
+
+  // Ensure the output directory exists
+  const dir = path.dirname(OUTPUT_PATH);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  fs.writeFileSync(OUTPUT_PATH, markdown, 'utf8');
+  console.log(`[fetch-skill-creator-guide] Saved to ${path.relative(process.cwd(), OUTPUT_PATH)}`);
+}
+
+module.exports = fetchGuide;
+
+// Allow direct invocation: node scripts/fetch-skill-creator-guide.js
+if (require.main === module) {
+  fetchGuide().catch((e) => {
+    console.warn(`[fetch-skill-creator-guide] Warning: ${e.message}`);
+    process.exit(0); // non-fatal
+  });
+}

--- a/optimus-plugin/skills/skill-checker/SKILL.md
+++ b/optimus-plugin/skills/skill-checker/SKILL.md
@@ -12,14 +12,11 @@ It checks file paths, naming conventions, MCP tool accuracy, and structural comp
 
 <instructions>
 
-## Step 1: Use the Official Skill Creator
+## Step 1: Reference the Official Skill Creator Methodology
 
-Invoke the official Claude Code `skill-creator` plugin to generate a high-quality skill:
-- Use `/skill-creator` in Create mode
-- Describe what the skill should teach (e.g., "Create a skill that teaches agents how to run database migrations")
-- The plugin will guide you through requirements gathering and generate a well-structured skill file
+Read the official guide at `.optimus/skills/skill-checker/official-guide.md` for the latest Claude skill-creator methodology (4 modes: Create, Eval, Improve, Benchmark). The guide is auto-fetched during builds and describes the recommended workflow including the 4 composable agents (Executor, Grader, Comparator, Analyzer).
 
-If the official plugin is not available, write the skill manually following the template in Step 3.
+If the guide file is not available, write the skill manually following the template in Step 3.
 
 ## Step 2: Apply Optimus Registration Rules
 
@@ -36,7 +33,7 @@ Before saving, ensure the generated skill complies with these project-specific r
 
 ## Step 3: Manual Template (Fallback)
 
-If the official `/skill-creator` plugin is unavailable, use this minimal template:
+If the official guide is unavailable, use this minimal template:
 
 <template>
 ---

--- a/optimus-plugin/skills/skill-checker/official-guide.md
+++ b/optimus-plugin/skills/skill-checker/official-guide.md
@@ -1,0 +1,28 @@
+# Official Claude Skill Creator Guide
+
+> Auto-fetched from https://claude.com/plugins/skill-creator on 2026-03-11.
+> This file is regenerated on each build. Do not edit manually.
+
+Skill Creator
+Create, improve, and measure skills. Use for creating, updating, evaluating, and benchmarking performance.
+
+Anthropic Verified
+
+Install in
+Claude Code
+
+Made by
+Anthropic
+
+Installs
+19066
+
+Play videoPlay video
+
+Skill Creator is a comprehensive toolkit for developing, testing, and iterating on Claude Code skills. It provides four operating modes — Create, Eval, Improve, and Benchmark — that guide you through the full skill development lifecycle, from initial concept to optimized, production-ready skills.
+
+Under the hood, four composable agents handle specialized tasks: an Executor that runs skills against eval prompts, a Grader that evaluates outputs against defined expectations, a Comparator that performs blind A/B comparisons between skill versions, and an Analyzer that suggests targeted improvements based on results. Together, these agents enable rigorous, data-driven skill refinement.
+
+The plugin also includes utility scripts for initializing skills, validating configurations, preparing evaluations, and aggregating benchmark results with variance analysis — so you can measure performance with statistical confidence.
+
+How to use: Invoke the skill with /skill-creator and choose a mode. Try prompts like: "Create a new skill that reviews PRs for security issues," "Run evals on my code-review skill," "Improve my deploy skill based on these test cases," or "Benchmark my skill across 10 runs and show variance." The interactive workflow will guide you through requirements gathering, test case creation, and iterative optimization.


### PR DESCRIPTION
Fixes #119

Adds a pre-build script that fetches the official Claude skill-creator plugin page and extracts the meaningful content (4 modes, 4 agents, usage instructions) into optimus-plugin/skills/skill-checker/official-guide.md.

## Changes
- New: optimus-plugin/scripts/fetch-skill-creator-guide.js - Node.js fetch script with HTML-to-text extraction and content filtering
- Modified: optimus-plugin/esbuild.plugin.js - integrates the fetch as a non-fatal pre-build step
- Modified: skill-checker/SKILL.md (both copies) - Step 1 now references official-guide.md instead of /skill-creator slash command
- New: optimus-plugin/skills/skill-checker/official-guide.md - auto-generated reference guide

The guide is regenerated on each build. If the fetch fails, the build continues and any existing guide is preserved.