### PR TITLE
[Optimus] feat: enhance vcs_create_work_item for ADO with new params, defaults, auto-tag and markdown conversion

### DIFF
--- a/src/adapters/vcs/AdoProvider.ts
+++ b/src/adapters/vcs/AdoProvider.ts
@@ -1,4 +1,5 @@
-import { IVcsProvider, WorkItemResult, PullRequestResult, CommentResult } from './IVcsProvider';
+import { IVcsProvider, WorkItemResult, PullRequestResult, CommentResult, AdoWorkItemOptions } from './IVcsProvider';
+import { marked } from 'marked';
 
 /**
  * Azure DevOps VCS Provider Implementation
@@ -9,17 +10,32 @@ import { IVcsProvider, WorkItemResult, PullRequestResult, CommentResult } from '
 export class AdoProvider implements IVcsProvider {
     private organization: string;
     private project: string;
+    private defaults?: {
+        work_item_type?: string;
+        area_path?: string;
+        iteration_path?: string;
+        assigned_to?: string;
+        auto_tags?: string[];
+    };
 
-    constructor(organization: string, project: string) {
+    constructor(organization: string, project: string, defaults?: {
+        work_item_type?: string;
+        area_path?: string;
+        iteration_path?: string;
+        assigned_to?: string;
+        auto_tags?: string[];
+    }) {
         this.organization = organization;
         this.project = project;
+        this.defaults = defaults;
     }
 
     async createWorkItem(
         title: string,
         body: string,
         labels?: string[],
-        workItemType: string = 'User Story'
+        workItemType?: string,
+        adoOptions?: AdoWorkItemOptions
     ): Promise<WorkItemResult> {
         const token = this.getToken();
         if (!token) {
@@ -27,31 +43,59 @@ export class AdoProvider implements IVcsProvider {
         }
 
         try {
-            // ADO Work Items API uses PATCH with JSON Patch format
-            const patchDocument = [
-                {
-                    op: 'add',
-                    path: '/fields/System.Title',
-                    value: title
-                },
-                {
-                    op: 'add',
-                    path: '/fields/System.Description',
-                    value: body
-                }
+            // Resolve values: call param > vcs.json default > fallback
+            const resolvedType = workItemType || this.defaults?.work_item_type || 'User Story';
+            const resolvedAreaPath = adoOptions?.area_path || this.defaults?.area_path;
+            const resolvedIterationPath = adoOptions?.iteration_path || this.defaults?.iteration_path;
+            const resolvedAssignedTo = adoOptions?.assigned_to || this.defaults?.assigned_to;
+            const resolvedPriority = adoOptions?.priority;
+            const resolvedParentId = adoOptions?.parent_id;
+
+            // Convert Markdown body to HTML for ADO rich-text rendering
+            const htmlBody = await marked.parse(body);
+
+            // Merge tags: user labels + auto_tags from config (deduplicated)
+            const autoTags = this.defaults?.auto_tags || [];
+            const userTags = labels || [];
+            const uniqueTags = [...new Set([...userTags, ...autoTags])];
+
+            // Build JSON Patch document
+            const patchDocument: Array<{op: string, path: string, value: any}> = [
+                { op: 'add', path: '/fields/System.Title', value: title },
+                { op: 'add', path: '/fields/System.Description', value: htmlBody }
             ];
 
-            // Add tags if provided (ADO uses semicolon-separated tags)
-            if (labels && labels.length > 0) {
+            if (resolvedAreaPath) {
+                patchDocument.push({ op: 'add', path: '/fields/System.AreaPath', value: resolvedAreaPath });
+            }
+            if (resolvedIterationPath) {
+                patchDocument.push({ op: 'add', path: '/fields/System.IterationPath', value: resolvedIterationPath });
+            }
+            if (resolvedAssignedTo) {
+                patchDocument.push({ op: 'add', path: '/fields/System.AssignedTo', value: resolvedAssignedTo });
+            }
+            if (resolvedPriority !== undefined) {
+                patchDocument.push({ op: 'add', path: '/fields/Microsoft.VSTS.Common.Priority', value: resolvedPriority });
+            }
+            if (uniqueTags.length > 0) {
+                patchDocument.push({ op: 'add', path: '/fields/System.Tags', value: uniqueTags.join('; ') });
+            }
+
+            // Parent hierarchy link
+            if (resolvedParentId) {
                 patchDocument.push({
                     op: 'add',
-                    path: '/fields/System.Tags',
-                    value: labels.join(';')
+                    path: '/relations/-',
+                    value: {
+                        rel: 'System.LinkTypes.Hierarchy-Reverse',
+                        url: `https://dev.azure.com/${this.organization}/${this.project}/_apis/wit/workItems/${resolvedParentId}`,
+                        attributes: { comment: 'Auto-linked by Optimus Swarm' }
+                    }
                 });
             }
 
             const response = await fetch(
-                `https://dev.azure.com/${this.organization}/${this.project}/_apis/wit/workitems/$${workItemType}?api-version=7.0`,
+                `https://dev.azure.com/${this.organization}/${this.project}/_apis/wit/workitems/$${resolvedType}?api-version=7.0`,
                 {
                     method: 'POST',
                     headers: {
@@ -72,7 +116,7 @@ export class AdoProvider implements IVcsProvider {
 
             return {
                 id: data.id.toString(),
-                number: data.id, // ADO uses ID as the work item number
+                number: data.id,
                 url: data._links.html.href,
                 title: data.fields['System.Title']
             };

--- a/src/adapters/vcs/GitHubProvider.ts
+++ b/src/adapters/vcs/GitHubProvider.ts
@@ -1,4 +1,4 @@
-import { IVcsProvider, WorkItemResult, PullRequestResult, CommentResult } from './IVcsProvider';
+import { IVcsProvider, WorkItemResult, PullRequestResult, CommentResult, AdoWorkItemOptions } from './IVcsProvider';
 
 /**
  * GitHub VCS Provider Implementation
@@ -19,7 +19,8 @@ export class GitHubProvider implements IVcsProvider {
         title: string,
         body: string,
         labels?: string[],
-        workItemType?: string // Ignored for GitHub
+        workItemType?: string, // Ignored for GitHub
+        _adoOptions?: AdoWorkItemOptions // Accepted but ignored
     ): Promise<WorkItemResult> {
         const token = this.getToken();
         if (!token) {

--- a/src/adapters/vcs/IVcsProvider.ts
+++ b/src/adapters/vcs/IVcsProvider.ts
@@ -24,6 +24,14 @@ export interface CommentResult {
     url: string;
 }
 
+export interface AdoWorkItemOptions {
+    iteration_path?: string;
+    area_path?: string;
+    assigned_to?: string;
+    parent_id?: number;
+    priority?: number;
+}
+
 /**
  * Unified VCS Provider Interface
  *
@@ -38,13 +46,15 @@ export interface IVcsProvider {
      * @param body - Work item description/body
      * @param labels - Labels/tags to apply
      * @param workItemType - ADO-specific work item type (Bug, User Story, Task). Ignored by GitHub.
+     * @param adoOptions - ADO-specific options (iteration, area, assigned_to, parent, priority). Ignored by GitHub.
      * @returns Promise with created work item details
      */
     createWorkItem(
         title: string,
         body: string,
         labels?: string[],
-        workItemType?: string
+        workItemType?: string,
+        adoOptions?: AdoWorkItemOptions
     ): Promise<WorkItemResult>;
 
     /**

--- a/src/adapters/vcs/VcsProviderFactory.ts
+++ b/src/adapters/vcs/VcsProviderFactory.ts
@@ -6,12 +6,21 @@ import { execSync } from 'child_process';
 export interface VcsConfig {
     provider?: 'auto-detect' | 'github' | 'azure-devops';
     github?: {
+        auth?: string;
         owner: string;
         repo: string;
     };
     ado?: {
+        auth?: string;
         organization: string;
         project: string;
+        defaults?: {
+            work_item_type?: string;
+            area_path?: string;
+            iteration_path?: string;
+            assigned_to?: string;
+            auto_tags?: string[];
+        };
     };
 }
 
@@ -59,7 +68,8 @@ export class VcsProviderFactory {
         } else if (providerType === 'azure-devops') {
             const { organization, project } = this.getAdoInfo(config, resolvedWorkspacePath);
             const { AdoProvider } = await import('./AdoProvider');
-            provider = new AdoProvider(organization, project);
+            const adoDefaults = config.ado?.defaults;
+            provider = new AdoProvider(organization, project, adoDefaults);
         } else {
             throw new Error(`Unsupported or undetectable VCS provider: ${providerType}`);
         }

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -347,10 +347,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: "object",
           properties: {
             title: { type: "string", description: "Work item title" },
-            body: { type: "string", description: "Work item description/body" },
+            body: { type: "string", description: "Work item description/body (Markdown — auto-converted to HTML for ADO)" },
             labels: { type: "array", items: { type: "string" }, description: "Labels/tags to apply" },
             work_item_type: { type: "string", description: "ADO work item type (Bug, User Story, Task). Ignored for GitHub." },
-            workspace_path: { type: "string", description: "Absolute path to the project workspace root." }
+            workspace_path: { type: "string", description: "Absolute path to the project workspace root." },
+            iteration_path: { type: "string", description: "ADO Sprint/iteration path (e.g. 'Project\\Sprint 1'). Ignored for GitHub." },
+            area_path: { type: "string", description: "ADO team/area path (e.g. 'Project\\Team\\Area'). Ignored for GitHub." },
+            assigned_to: { type: "string", description: "ADO assigned user (email or alias). Ignored for GitHub." },
+            parent_id: { type: "number", description: "ADO parent work item ID for hierarchy linking. Ignored for GitHub." },
+            priority: { type: "number", description: "ADO priority (1-4, where 1=Critical). Ignored for GitHub." }
           },
           required: ["title", "body", "workspace_path"]
         }
@@ -836,14 +841,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       content: [{ type: "text", text: result }]
     };
   } else if (request.params.name === "vcs_create_work_item") {
-    const { title, body, labels, work_item_type, workspace_path } = request.params.arguments as any;
+    const { title, body, labels, work_item_type, workspace_path,
+            iteration_path, area_path, assigned_to, parent_id, priority } = request.params.arguments as any;
     if (!title || !body || !workspace_path) {
       throw new McpError(ErrorCode.InvalidParams, "Invalid arguments: requires title, body, and workspace_path");
     }
 
     try {
       const vcsProvider = await VcsProviderFactory.getProvider(workspace_path);
-      const result = await vcsProvider.createWorkItem(title, body, labels, work_item_type);
+      const result = await vcsProvider.createWorkItem(title, body, labels, work_item_type, {
+        iteration_path,
+        area_path,
+        assigned_to,
+        parent_id,
+        priority
+      });
 
       return {
         content: [{


### PR DESCRIPTION
## Summary

Enhances the ADO provider's `createWorkItem` method and MCP tool schema with:
- 5 new optional parameters: `iteration_path`, `area_path`, `assigned_to`, `parent_id`, `priority`
- Default values from `vcs.json` config (`ado.defaults` block)
- Auto-tag merge: user labels + config `auto_tags` (deduplicated)
- Markdown-to-HTML body conversion via `marked` for ADO rich-text rendering
- Parent work item hierarchy linking via ADO relation patch

Fixes #129

## Files Changed

| File | Change |
|------|--------|
| `src/adapters/vcs/VcsProviderFactory.ts` | Expanded `VcsConfig` with `ado.defaults`, pass defaults to `AdoProvider` constructor |
| `src/adapters/vcs/IVcsProvider.ts` | Added `AdoWorkItemOptions` interface, updated `createWorkItem` signature |
| `src/adapters/vcs/AdoProvider.ts` | Major overhaul: defaults resolution, `marked` HTML conversion, auto-tag merge, parent link |
| `src/adapters/vcs/GitHubProvider.ts` | Updated signature to accept (and ignore) `adoOptions` |
| `src/mcp/mcp-server.ts` | Added 5 new params to tool schema, updated handler extraction |

## Resolution Priority

All parameters follow: **call param > vcs.json default > fallback**

## Test Plan

- [ ] Verify build passes with 0 errors (confirmed: 208.5kb bundle, `marked` bundled correctly)
- [ ] Verify JSON Patch structure matches ADO API v7.0 spec
- [ ] Verify GitHub provider ignores new params without side effects
- [ ] Live test with ADO credentials (requires PAT)