### PR TITLE
[Optimus] docs: update README and system-instructions for v0.3.0 features

### DIFF
--- a/.optimus/config/system-instructions.md
+++ b/.optimus/config/system-instructions.md
@@ -87,6 +87,27 @@ When delegating, engine and model are resolved in priority order:
 3. `available-agents.json` (first non-demo engine + first model)
 4. Hardcoded fallback: `claude-code`
 
+## Plan Mode
+
+Orchestrator roles (e.g., product-manager, chief-architect) run with `mode: plan`. In plan mode:
+- The agent **cannot** write to source code files — only to `.optimus/` artifacts via `write_blackboard_artifact`.
+- The agent **must** delegate implementation work to dev roles (e.g., `senior-full-stack-builder`).
+- This enforces separation of concerns: orchestrators plan, developers code.
+
+## Delegation Depth Control
+
+Agent delegation is limited to a maximum of **3 nested layers** to prevent infinite recursion:
+- Tracked via `OPTIMUS_DELEGATION_DEPTH` environment variable, automatically injected and incremented.
+- At depth 3, MCP configuration is stripped from the child process, preventing further delegation.
+- `MAX_DELEGATION_DEPTH = 3` is defined in `src/constants.ts`.
+
+## Issue Lineage Tracking
+
+When delegating sub-tasks, the `OPTIMUS_PARENT_ISSUE` environment variable is automatically injected into child agent processes:
+- This allows child-created Issues to maintain a parent-child relationship with the original tracking Issue.
+- The `parent_issue_number` parameter in `delegate_task` / `delegate_task_async` sets the lineage root.
+- Enables traceability of complex multi-agent workflows back to a single originating Issue.
+
 ## VCS Auto-Tagging
 All Work Items and PRs created via MCP tools are automatically tagged with `[Optimus]` prefix and `optimus-bot` label for traceability across both GitHub and Azure DevOps platforms.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ Use these values in your client's MCP server configuration:
 | **args** | `["-y", "github:cloga/optimus-code", "serve"]` |
 | **transport** | `stdio` |
 
+### Upgrading an existing workspace
+
+If you've previously initialized and want to update to the latest skills, roles, and config:
+
+```bash
+npx -y github:cloga/optimus-code upgrade
+```
+
+This force-updates skills, roles, and config from the latest release while preserving your agents (`.optimus/agents/`), runtime data (`.optimus/state/`), and memory.
+
 ### Step 3: (Optional) Enable GitHub integration
 
 Create a `.env` file in your project root:
@@ -92,6 +102,30 @@ GITHUB_TOKEN=ghp_your_token_here
 ```
 
 This enables automated Issue tracking and PR creation via the built-in PM agent.
+
+### Step 3b: (Optional) Enable Azure DevOps integration
+
+Create `.optimus/config/vcs.json`:
+
+```json
+{
+  "provider": "azure-devops",
+  "ado": {
+    "organization": "your-org",
+    "project": "your-project",
+    "auth": "env:ADO_PAT",
+    "defaults": {
+      "work_item_type": "User Story",
+      "area_path": "Project\\Team\\Area",
+      "iteration_path": "Project\\Sprint 1",
+      "assigned_to": "user@example.com",
+      "auto_tags": ["created-by:optimus-code"]
+    }
+  }
+}
+```
+
+The `defaults` section is optional. Any field not provided will use ADO project defaults. All defaults can be overridden per-call via MCP tool parameters.
 
 ---
 
@@ -130,6 +164,20 @@ Once the server is running, your AI assistant gains these tools:
 | `required_skills` | | Skills the agent needs (pre-flight checked) |
 
 ---
+
+## Features
+
+### v0.3.0 Highlights
+
+- **Plan Mode** — Orchestrator roles (PM, Architect) run with `mode: plan`, cannot write source code, and must delegate implementation to dev roles.
+- **Delegation Depth Control** — Maximum 3 layers of nested agent delegation, tracked via `OPTIMUS_DELEGATION_DEPTH` to prevent infinite recursion.
+- **Issue Lineage Tracking** — `OPTIMUS_PARENT_ISSUE` is automatically injected into child agent processes, maintaining parent-child relationships across GitHub Issues.
+- **`write_blackboard_artifact` Tool** — Allows plan-mode agents to write proposals, requirements, and reports to `.optimus/` without source code write access.
+- **`optimus upgrade` Command** — Safe incremental upgrade that refreshes skills, roles, and config while preserving user agents and runtime data.
+- **Enhanced ADO Work Items** — `vcs_create_work_item` supports `area_path`, `iteration_path`, `assigned_to`, `parent_id`, `priority` with `vcs.json` defaults, Markdown→HTML conversion, and auto-tagging.
+- **Engine/Model Validation** — Engine and model names are validated against `available-agents.json` before being persisted to role templates.
+- **Auto-Skill Genesis** — Skills are auto-generated after successful T3 role execution.
+- **Rich T3→T2 Precipitation** — New roles get professional-grade role definitions via `agent-creator` instead of thin fallback templates.
 
 ## How It Works
 
@@ -206,6 +254,7 @@ optimus serve
 ```
 optimus init        Bootstrap .optimus/ workspace in current directory
 optimus serve       Start MCP server (stdio transport)
+optimus upgrade     Update skills, roles, and config to latest version (preserves agents and runtime data)
 optimus version     Print version
 optimus help        Show help
 ```

--- a/optimus-plugin/scaffold/config/system-instructions.md
+++ b/optimus-plugin/scaffold/config/system-instructions.md
@@ -87,6 +87,27 @@ When delegating, engine and model are resolved in priority order:
 3. `available-agents.json` (first non-demo engine + first model)
 4. Hardcoded fallback: `claude-code`
 
+## Plan Mode
+
+Orchestrator roles (e.g., product-manager, chief-architect) run with `mode: plan`. In plan mode:
+- The agent **cannot** write to source code files — only to `.optimus/` artifacts via `write_blackboard_artifact`.
+- The agent **must** delegate implementation work to dev roles (e.g., `senior-full-stack-builder`).
+- This enforces separation of concerns: orchestrators plan, developers code.
+
+## Delegation Depth Control
+
+Agent delegation is limited to a maximum of **3 nested layers** to prevent infinite recursion:
+- Tracked via `OPTIMUS_DELEGATION_DEPTH` environment variable, automatically injected and incremented.
+- At depth 3, MCP configuration is stripped from the child process, preventing further delegation.
+- `MAX_DELEGATION_DEPTH = 3` is defined in `src/constants.ts`.
+
+## Issue Lineage Tracking
+
+When delegating sub-tasks, the `OPTIMUS_PARENT_ISSUE` environment variable is automatically injected into child agent processes:
+- This allows child-created Issues to maintain a parent-child relationship with the original tracking Issue.
+- The `parent_issue_number` parameter in `delegate_task` / `delegate_task_async` sets the lineage root.
+- Enables traceability of complex multi-agent workflows back to a single originating Issue.
+
 ## GitHub Auto-Tagging
 All Issues and PRs created via MCP tools are automatically tagged with `[Optimus]` prefix and `optimus-bot` label for traceability.
 


### PR DESCRIPTION
## Summary

Fixes #144

Documentation update for v0.3.0 features. No code changes.

### README.md
- **CLI Reference**: Added `optimus upgrade` command
- **Quick Start**: Added "Upgrading an existing workspace" subsection with `npx upgrade` command
- **Features**: Added new section with 9 v0.3.0 highlights (plan mode, delegation depth, issue lineage, blackboard artifact, upgrade CLI, ADO enhancements, engine/model validation, auto-skill genesis, rich T3 precipitation)
- **ADO Configuration**: Added "Step 3b" with `vcs.json` example for Azure DevOps integration

### system-instructions.md (host + scaffold)
Added 3 new sections to Part 1 after "Engine/Model Resolution":
- **Plan Mode** — orchestrator separation of concerns
- **Delegation Depth Control** — `OPTIMUS_DELEGATION_DEPTH` and `MAX_DELEGATION_DEPTH = 3`
- **Issue Lineage Tracking** — `OPTIMUS_PARENT_ISSUE` for parent-child Issue relationships

Both `.optimus/config/system-instructions.md` and `optimus-plugin/scaffold/config/system-instructions.md` are kept in sync.