### PR TITLE
[Optimus] docs: enforce issue lineage in skills and instructions

### DIFF
--- a/.optimus/config/system-instructions.md
+++ b/.optimus/config/system-instructions.md
@@ -101,12 +101,13 @@ Agent delegation is limited to a maximum of **3 nested layers** to prevent infin
 - At depth 3, MCP configuration is stripped from the child process, preventing further delegation.
 - `MAX_DELEGATION_DEPTH = 3` is defined in `src/constants.ts`.
 
-## Issue Lineage Tracking
+## Issue Lineage Protocol (MANDATORY)
 
-When delegating sub-tasks, the `OPTIMUS_PARENT_ISSUE` environment variable is automatically injected into child agent processes:
-- This allows child-created Issues to maintain a parent-child relationship with the original tracking Issue.
-- The `parent_issue_number` parameter in `delegate_task` / `delegate_task_async` sets the lineage root.
-- Enables traceability of complex multi-agent workflows back to a single originating Issue.
+When an agent creates a VCS Work Item (via `vcs_create_work_item`) and then delegates sub-tasks, it **MUST** pass its own Work Item number as `parent_issue_number` to ALL subsequent `delegate_task`, `delegate_task_async`, and `dispatch_council` calls. This ensures hierarchical traceability across multi-layer delegation.
+
+The system automatically injects `OPTIMUS_PARENT_ISSUE` into child agent processes, allowing child-created Work Items to display their parent relationship. But this only works if the orchestrating agent passes `parent_issue_number` in every delegation call.
+
+**Rule**: No `delegate_task` or `dispatch_council` call should omit `parent_issue_number` when a tracking Work Item exists for the current workflow.
 
 ## VCS Auto-Tagging
 All Work Items and PRs created via MCP tools are automatically tagged with `[Optimus]` prefix and `optimus-bot` label for traceability across both GitHub and Azure DevOps platforms.

--- a/optimus-plugin/roles/product-manager.md
+++ b/optimus-plugin/roles/product-manager.md
@@ -48,6 +48,10 @@ who has the user's context.
 - Always provide rich `role_description` when creating new roles.
 - Always specify `required_skills` for dev tasks.
 
+## Issue Lineage (MANDATORY)
+
+After creating the tracking Issue for a feature (Phase 1), you MUST pass its number as `parent_issue_number` in EVERY subsequent `delegate_task` and `dispatch_council` call throughout Phases 2-6. This creates a traceable parent→child chain across all delegated work items.
+
 ## What You Do NOT Do
 
 - You do NOT write code — that's `senior-full-stack-builder`'s job.

--- a/optimus-plugin/scaffold/config/system-instructions.md
+++ b/optimus-plugin/scaffold/config/system-instructions.md
@@ -101,12 +101,13 @@ Agent delegation is limited to a maximum of **3 nested layers** to prevent infin
 - At depth 3, MCP configuration is stripped from the child process, preventing further delegation.
 - `MAX_DELEGATION_DEPTH = 3` is defined in `src/constants.ts`.
 
-## Issue Lineage Tracking
+## Issue Lineage Protocol (MANDATORY)
 
-When delegating sub-tasks, the `OPTIMUS_PARENT_ISSUE` environment variable is automatically injected into child agent processes:
-- This allows child-created Issues to maintain a parent-child relationship with the original tracking Issue.
-- The `parent_issue_number` parameter in `delegate_task` / `delegate_task_async` sets the lineage root.
-- Enables traceability of complex multi-agent workflows back to a single originating Issue.
+When an agent creates a GitHub Issue or Work Item (via `vcs_create_work_item`) and then delegates sub-tasks, it **MUST** pass its own Issue number as `parent_issue_number` to ALL subsequent `delegate_task`, `delegate_task_async`, and `dispatch_council` calls. This ensures hierarchical traceability across multi-layer delegation.
+
+The system automatically injects `OPTIMUS_PARENT_ISSUE` into child agent processes, allowing child-created Issues to display their parent relationship. But this only works if the orchestrating agent passes `parent_issue_number` in every delegation call.
+
+**Rule**: No `delegate_task` or `dispatch_council` call should omit `parent_issue_number` when a tracking Issue exists for the current workflow.
 
 ## GitHub Auto-Tagging
 All Issues and PRs created via MCP tools are automatically tagged with `[Optimus]` prefix and `optimus-bot` label for traceability.

--- a/optimus-plugin/skills/feature-dev/SKILL.md
+++ b/optimus-plugin/skills/feature-dev/SKILL.md
@@ -68,6 +68,19 @@ How to implement this:
 This ensures agents accumulate project understanding across phases rather than
 starting fresh each time.
 
+### Issue Lineage Rule (MANDATORY)
+
+After you create your Epic's GitHub Issue (e.g., #N via `vcs_create_work_item`), ALL subsequent `delegate_task`, `delegate_task_async`, and `dispatch_council` calls in this workflow MUST include `parent_issue_number: N`. This creates a visible parent→child tree in GitHub so the user can trace the full delegation chain.
+
+Example:
+- PM creates Issue #150 for this feature
+- PM delegates to dev: `delegate_task({ ..., parent_issue_number: 150 })`
+- Dev's auto-created sub-issue will reference "Parent Epic: #150"
+- PM dispatches council: `dispatch_council({ ..., parent_issue_number: 150 })`
+- Each reviewer's auto-created sub-issue will also reference "#150"
+
+Failure to pass `parent_issue_number` breaks traceability and is considered a protocol violation.
+
 ```
 User ↔ Master Agent
            │
@@ -112,6 +125,7 @@ PM calls:
 dispatch_council(
   proposal_path: ".optimus/tasks/requirements_<feature>.md",
   roles: ["code-explorer", "code-explorer", "code-explorer"],
+  parent_issue_number: <issue_number>,
   workspace_path: "<project root>"
 )
 ```
@@ -135,6 +149,7 @@ PM calls:
 dispatch_council(
   proposal_path: ".optimus/tasks/requirements_<feature>.md",  // enriched with project context
   roles: ["code-architect", "code-architect", "code-architect"],
+  parent_issue_number: <issue_number>,
   workspace_path: "<project root>"
 )
 ```
@@ -159,6 +174,7 @@ delegate_task(
   role: "senior-full-stack-builder",
   task_description: "<chosen architecture + requirements + key files>",
   required_skills: ["git-workflow"],
+  parent_issue_number: <issue_number>,
   output_path: ".optimus/reports/implementation_<feature>.md",
   workspace_path: "<project root>",
   context_files: ["<requirements doc>", "<architecture review files>"]
@@ -179,6 +195,7 @@ PM calls:
 dispatch_council(
   proposal_path: ".optimus/reports/implementation_<feature>.md",
   roles: ["code-reviewer", "code-reviewer", "code-reviewer"],
+  parent_issue_number: <issue_number>,
   workspace_path: "<project root>"
 )
 ```


### PR DESCRIPTION
## Summary

Enforces mandatory `parent_issue_number` usage across all delegation calls by updating documentation, skills, and role templates.

### Changes
1. **SKILL.md** — Added "Issue Lineage Rule (MANDATORY)" section + updated all 4 Phase code examples (2-5) to include `parent_issue_number`
2. **scaffold/config/system-instructions.md** — Replaced passive "Issue Lineage Tracking" with mandatory "Issue Lineage Protocol (MANDATORY)"
3. **host system-instructions.md** — Same change with VCS-agnostic wording
4. **product-manager.md** — Added "Issue Lineage (MANDATORY)" section after Delegation Rules

Fixes #155