### PR TITLE
[Optimus] feat: implement agent retirement, quarantine and T1 GC, fixes #161

### DIFF
--- a/src/mcp/agent-gc.ts
+++ b/src/mcp/agent-gc.ts
@@ -1,0 +1,52 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Garbage-collect stale T1 agent instances.
+ * Scans .optimus/agents/*.md, deletes files where last_invoked > maxAgeDays
+ * or last_invoked is missing. Skips files with `persistent: true`.
+ */
+export function cleanStaleAgents(workspacePath: string, maxAgeDays: number = 7): void {
+    const agentsDir = path.join(workspacePath, '.optimus', 'agents');
+    if (!fs.existsSync(agentsDir)) return;
+
+    const files = fs.readdirSync(agentsDir).filter(f => f.endsWith('.md'));
+    const now = Date.now();
+    const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
+
+    for (const file of files) {
+        // Skip .lock files
+        if (file.endsWith('.lock')) continue;
+
+        const filePath = path.join(agentsDir, file);
+        const content = fs.readFileSync(filePath, 'utf8');
+
+        // Parse frontmatter manually (simple key-value)
+        const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+        if (!fmMatch) continue;
+
+        const lines = fmMatch[1].split('\n');
+        const getValue = (key: string) => {
+            const line = lines.find(l => l.startsWith(`${key}:`));
+            return line ? line.slice(key.length + 1).trim().replace(/^['"]|['"]$/g, '') : undefined;
+        };
+
+        // Skip persistent agents
+        if (getValue('persistent') === 'true') continue;
+
+        // Check last_invoked (or fall back to created_at)
+        const lastInvoked = getValue('last_invoked') || getValue('created_at');
+        if (!lastInvoked) {
+            // No timestamp at all — delete
+            fs.unlinkSync(filePath);
+            console.error(`[Agent GC] Removed stale T1 instance '${file}' (no timestamp found)`);
+            continue;
+        }
+
+        const age = now - new Date(lastInvoked).getTime();
+        if (age > maxAgeMs) {
+            fs.unlinkSync(filePath);
+            console.error(`[Agent GC] Removed stale T1 instance '${file}' (last invoked: ${lastInvoked})`);
+        }
+    }
+}

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -12,7 +12,8 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 import crypto from "crypto";
-import { dispatchCouncilConcurrent, delegateTaskSingle, loadValidEnginesAndModels, isValidEngine, isValidModel } from "./worker-spawner";
+import { dispatchCouncilConcurrent, delegateTaskSingle, loadValidEnginesAndModels, isValidEngine, isValidModel, updateFrontmatter, loadT3UsageLog, saveT3UsageLog } from "./worker-spawner";
+import { cleanStaleAgents } from "./agent-gc";
 import { TaskManifestManager } from "../managers/TaskManifestManager";
 import { parseGitRemote, createGitHubIssue } from "../utils/githubApi";
 import { runAsyncWorker } from "./council-runner";
@@ -413,6 +414,19 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ["name"]
         }
+      },
+      {
+        name: "quarantine_role",
+        description: "Manually quarantine or unquarantine a T2 role. Quarantined roles cannot be dispatched until unquarantined.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            role: { type: "string", description: "The role name to quarantine/unquarantine" },
+            action: { type: "string", enum: ["quarantine", "unquarantine"], description: "Whether to quarantine or unquarantine the role" },
+            workspace_path: { type: "string", description: "Absolute path to the project workspace root." }
+          },
+          required: ["role", "action", "workspace_path"]
+        }
       }
     ],
   };
@@ -734,17 +748,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             const content = fs.readFileSync(path.join(t2Dir, f), 'utf8');
             const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
             let engineInfo = '';
+            let quarantineMarker = '';
             if (fmMatch) {
               const lines = fmMatch[1].split('\n');
               const engineLine = lines.find(l => l.startsWith('engine:'));
               const modelLine = lines.find(l => l.startsWith('model:'));
+              const statusLine = lines.find(l => l.startsWith('status:'));
               if (engineLine || modelLine) {
                 const engine = engineLine ? engineLine.split(':')[1].trim() : '?';
                 const model = modelLine ? modelLine.split(':')[1].trim() : '?';
                 engineInfo = ` → \`${engine}\` / \`${model}\``;
               }
+              if (statusLine && statusLine.split(':')[1].trim() === 'quarantined') {
+                quarantineMarker = ' **[QUARANTINED]**';
+              }
             }
-            roster += `- ${roleName}${engineInfo}\n`;
+            roster += `- ${roleName}${engineInfo}${quarantineMarker}\n`;
           } catch {
             roster += `- ${roleName}\n`;
           }
@@ -1034,6 +1053,53 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       throw new McpError(ErrorCode.InvalidParams, "Missing required parameter: name");
     }
     return { content: [{ type: "text", text: `Hello, ${name}! Optimus Swarm is running.` }] };
+  } else if (request.params.name === "quarantine_role") {
+    const { role, action, workspace_path } = request.params.arguments as any;
+    if (!role || !action || !workspace_path) {
+      throw new McpError(ErrorCode.InvalidParams, "Missing required parameters: role, action, workspace_path");
+    }
+
+    const t2Dir = path.join(workspace_path, '.optimus', 'roles');
+    const rolePath = path.join(t2Dir, `${role}.md`);
+    if (!fs.existsSync(rolePath)) {
+      return { content: [{ type: "text", text: `Role '${role}' not found at ${rolePath}` }] };
+    }
+
+    const content = fs.readFileSync(rolePath, 'utf8');
+
+    if (action === 'quarantine') {
+      const updated = updateFrontmatter(content, {
+        status: 'quarantined',
+        quarantined_at: new Date().toISOString()
+      });
+      fs.writeFileSync(rolePath, updated, 'utf8');
+
+      // Reset consecutive failures in T3 usage log
+      const log = loadT3UsageLog(workspace_path);
+      if (log[role]) {
+        log[role].consecutive_failures = 0;
+        saveT3UsageLog(workspace_path, log);
+      }
+
+      return { content: [{ type: "text", text: `Role '${role}' has been quarantined. It will be blocked from dispatch until unquarantined.` }] };
+    } else if (action === 'unquarantine') {
+      const updated = updateFrontmatter(content, {
+        status: 'idle',
+        quarantined_at: ''
+      });
+      fs.writeFileSync(rolePath, updated, 'utf8');
+
+      // Reset consecutive failures
+      const log = loadT3UsageLog(workspace_path);
+      if (log[role]) {
+        log[role].consecutive_failures = 0;
+        saveT3UsageLog(workspace_path, log);
+      }
+
+      return { content: [{ type: "text", text: `Role '${role}' has been unquarantined and is available for dispatch again.` }] };
+    } else {
+      throw new McpError(ErrorCode.InvalidParams, `Invalid action '${action}'. Must be 'quarantine' or 'unquarantine'.`);
+    }
   }
 
   throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${request.params.name}`);
@@ -1058,6 +1124,14 @@ if (process.argv.includes("--run-task")) {
     const transport = new StdioServerTransport();
     await server.connect(transport);
     console.error("Optimus Spartan Swarm MCP server running on stdio");
+
+    // Agent GC: clean up stale T1 instances on startup
+    const workspaceRoot = process.env.OPTIMUS_WORKSPACE_ROOT || process.cwd();
+    try {
+      cleanStaleAgents(workspaceRoot);
+    } catch (e: any) {
+      console.error(`[Agent GC] Warning: ${e.message}`);
+    }
   }
 
   main().catch((error) => {

--- a/src/mcp/worker-spawner.ts
+++ b/src/mcp/worker-spawner.ts
@@ -29,7 +29,7 @@ function parseFrontmatter(content: string): { frontmatter: Record<string, string
     return { frontmatter, body };
 }
 
-function updateFrontmatter(content: string, updates: Record<string, string>): string {
+export function updateFrontmatter(content: string, updates: Record<string, string>): string {
     const parsed = parseFrontmatter(content);
     const newFm = { ...parsed.frontmatter, ...updates };
     
@@ -59,6 +59,7 @@ interface T3UsageEntry {
     invocations: number;
     successes: number;
     failures: number;
+    consecutive_failures: number;
     lastUsed: string;
     engine: string;
     model?: string;
@@ -68,7 +69,7 @@ function getT3UsageLogPath(workspacePath: string): string {
     return path.join(workspacePath, '.optimus', 'state', 't3-usage-log.json');
 }
 
-function loadT3UsageLog(workspacePath: string): Record<string, T3UsageEntry> {
+export function loadT3UsageLog(workspacePath: string): Record<string, T3UsageEntry> {
     const logPath = getT3UsageLogPath(workspacePath);
     try {
         if (fs.existsSync(logPath)) {
@@ -78,7 +79,7 @@ function loadT3UsageLog(workspacePath: string): Record<string, T3UsageEntry> {
     return {};
 }
 
-function saveT3UsageLog(workspacePath: string, log: Record<string, T3UsageEntry>): void {
+export function saveT3UsageLog(workspacePath: string, log: Record<string, T3UsageEntry>): void {
     const logPath = getT3UsageLogPath(workspacePath);
     const dir = path.dirname(logPath);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
@@ -90,11 +91,19 @@ function trackT3Usage(workspacePath: string, role: string, success: boolean, eng
     t3LogMutex = t3LogMutex.then(() => {
         const log = loadT3UsageLog(workspacePath);
         if (!log[role]) {
-            log[role] = { role, invocations: 0, successes: 0, failures: 0, lastUsed: '', engine, model };
+            log[role] = { role, invocations: 0, successes: 0, failures: 0, consecutive_failures: 0, lastUsed: '', engine, model };
+        }
+        if (log[role].consecutive_failures === undefined) {
+            log[role].consecutive_failures = 0;
         }
         log[role].invocations++;
-        if (success) log[role].successes++;
-        else log[role].failures++;
+        if (success) {
+            log[role].successes++;
+            log[role].consecutive_failures = 0;
+        } else {
+            log[role].failures++;
+            log[role].consecutive_failures++;
+        }
         log[role].lastUsed = new Date().toISOString();
         log[role].engine = engine;
         if (model) log[role].model = model;
@@ -729,6 +738,29 @@ export async function delegateTaskSingle(roleArg: string, taskPath: string, outp
         if (fm.frontmatter.mode && !masterInfo?.mode) activeMode = fm.frontmatter.mode as 'agent' | 'plan';
     }
 
+    // --- Pre-Flight: Quarantine check ---
+    if (t1Content) {
+        const qfm = parseFrontmatter(t1Content);
+        if (qfm.frontmatter.status === 'quarantined') {
+            throw new Error(
+                `⚠️ **Role Quarantined**: Role '${role}' is quarantined due to repeated failures ` +
+                `(quarantined at: ${qfm.frontmatter.quarantined_at || 'unknown'}). ` +
+                `Fix the role template at '.optimus/roles/${role}.md' or delete it to allow T3 re-creation.`
+            );
+        }
+    }
+    // Also check the T2 directly (T1 might have been created before quarantine)
+    if (fs.existsSync(t2Path)) {
+        const t2Fm = parseFrontmatter(fs.readFileSync(t2Path, 'utf8'));
+        if (t2Fm.frontmatter.status === 'quarantined') {
+            throw new Error(
+                `⚠️ **Role Quarantined**: Role '${role}' is quarantined due to repeated failures ` +
+                `(quarantined at: ${t2Fm.frontmatter.quarantined_at || 'unknown'}). ` +
+                `Fix the role template at '.optimus/roles/${role}.md' or delete it to allow T3 re-creation.`
+            );
+        }
+    }
+
     // Fallback: if engine/model still unset, try reading available-agents.json
     if (!activeEngine) {
         const configPath = path.join(workspacePath, '.optimus', 'config', 'available-agents.json');
@@ -865,7 +897,7 @@ ${personaContext ? `--- START PERSONA INSTRUCTIONS ---\n${personaContext}\n--- E
 
 Goal: Execute the following task.
 System Note: ${personaProof}
-
+${trackingIssueHeader}
 Task Description:
 ${taskText}${contextContent}${skillContent ? `\n\n=== EQUIPPED SKILLS ===\nThe following skills have been loaded for you to reference and follow:\n${skillContent}\n=== END SKILLS ===` : ''}
 
@@ -880,9 +912,6 @@ Please provide your complete execution result below.`;
 
         // --- Pre-Flight: Ensure T2 role template exists BEFORE creating T1 ---
         // Logical order: T2 (role definition) → T1 (instance). Never create T1 without T2.
-        if (isT3) {
-            trackT3Usage(workspacePath, role, true, activeEngine, activeModel);
-        }
         await ensureT2Role(workspacePath, role, activeEngine, activeModel, masterInfo, currentDepth);
 
         // --- Pre-Flight: Create T1 instance placeholder from T2 template ---
@@ -919,6 +948,9 @@ Please provide your complete execution result below.`;
         } else {
             // Explicitly clear inherited env var to prevent stale grandparent references
             extraEnv.OPTIMUS_PARENT_ISSUE = '';
+        }
+        if (autoIssueNumber !== undefined) {
+            extraEnv.OPTIMUS_TRACKING_ISSUE = String(autoIssueNumber);
         }
         const response = await adapter.invoke(basePrompt, activeMode, activeSessionId, undefined, extraEnv);
 
@@ -958,7 +990,10 @@ Please provide your complete execution result below.`;
         const currentT1 = fs.existsSync(t1TempPath) ? t1TempPath : t1Path;
         if (currentT1 && fs.existsSync(currentT1)) {
             const currentStr = fs.readFileSync(currentT1, 'utf8');
-            const updates: Record<string, string> = { status: 'idle' };
+            const updates: Record<string, string> = {
+                status: 'idle',
+                last_invoked: new Date().toISOString()
+            };
             const newSessionId = adapter.lastSessionId;
             if (newSessionId) {
                 updates.session_id = newSessionId;
@@ -981,6 +1016,11 @@ Please provide your complete execution result below.`;
 
         fs.writeFileSync(outputPath, response, 'utf8');
 
+        // Track T3 success AFTER we know execution succeeded
+        if (isT3) {
+            trackT3Usage(workspacePath, role, true, activeEngine, activeModel);
+        }
+
         // T2 Role Enhancement: asynchronously upgrade thin T2 template using agent-creator
         if (isT3) {
             try {
@@ -996,6 +1036,21 @@ Please provide your complete execution result below.`;
         // Track T3 failures too
         if (isT3) {
             trackT3Usage(workspacePath, role, false, activeEngine, activeModel);
+        }
+        // Check quarantine threshold: 3+ consecutive failures with 0 successes
+        const log = loadT3UsageLog(workspacePath);
+        const entry = log[role];
+        if (entry && entry.consecutive_failures >= 3 && entry.successes === 0) {
+            const t2RolePath = path.join(workspacePath, '.optimus', 'roles', `${sanitizeRoleName(role)}.md`);
+            if (fs.existsSync(t2RolePath)) {
+                const t2Content = fs.readFileSync(t2RolePath, 'utf8');
+                const quarantined = updateFrontmatter(t2Content, {
+                    status: 'quarantined',
+                    quarantined_at: new Date().toISOString()
+                });
+                fs.writeFileSync(t2RolePath, quarantined, 'utf8');
+                console.error(`[Meta-Immune] Role '${role}' quarantined after ${entry.consecutive_failures} consecutive failures with 0 successes`);
+            }
         }
         throw new Error(`Worker execution failed: ${e.message}`);
     } finally {


### PR DESCRIPTION
## Summary

Implements the **Meta-Immune System** for the Spartan Swarm — agent retirement, quarantine, and garbage collection.

### Changes

**Worker-Spawner (worker-spawner.ts):**
- **Consecutive failure tracking**: T3 usage log now tracks `consecutive_failures` per role, resetting on success
- **Auto-quarantine**: Roles with 3+ consecutive failures and 0 successes are automatically quarantined (status set in T2 frontmatter)
- **Pre-flight quarantine check**: Dispatch to quarantined roles is blocked before execution with a clear error message
- **Fix trackT3Usage timing**: Success tracking moved post-execution (after output written), failure tracking stays in catch block
- **Track `last_invoked`**: T1 agent instances now get `last_invoked` timestamp after each use
- **Export helpers**: `updateFrontmatter`, `loadT3UsageLog`, `saveT3UsageLog` exported for cross-module use

**MCP Server (mcp-server.ts):**
- **`quarantine_role` tool**: New tool for manual quarantine/unquarantine of T2 roles, resets consecutive failures
- **Quarantine marker in `roster_check`**: Quarantined T2 roles show `[QUARANTINED]` marker
- **Agent GC at startup**: `cleanStaleAgents()` runs on MCP server boot, removing T1 instances older than 7 days

**Agent GC (agent-gc.ts — new file):**
- `cleanStaleAgents()` scans `.optimus/agents/*.md`, deletes files where `last_invoked` exceeds `maxAgeDays` (default: 7)
- Respects `persistent: true` frontmatter to skip protected agents
- Falls back to `created_at` if `last_invoked` is missing

Closes #161