### PR TITLE
[Optimus] feat: inject auto-created issue ID into agent prompt to prevent duplicates, fixes #166

### DIFF
--- a/optimus-plugin/skills/feature-dev/SKILL.md
+++ b/optimus-plugin/skills/feature-dev/SKILL.md
@@ -114,6 +114,15 @@ that's complete enough for all downstream work.
 
 After this phase, Master hands off to PM via `delegate_task_async` for Phase 2-6.
 
+### Pre-Existing Tracking Issue
+
+If your prompt header contains a "## Tracking Issue" section with an existing Issue number (e.g., #N), that Issue was auto-created by the system to track this task. In that case:
+- **DO NOT** create a new Issue via `vcs_create_work_item`
+- Use #N as your Epic Issue for all sub-delegations (`parent_issue_number: N`)
+- You can also check the `OPTIMUS_TRACKING_ISSUE` environment variable as a fallback
+
+This prevents duplicate Issues from being created for the same task.
+
 ---
 
 ## Phase 2: Codebase Exploration

--- a/optimus-plugin/skills/git-workflow/SKILL.md
+++ b/optimus-plugin/skills/git-workflow/SKILL.md
@@ -28,7 +28,11 @@ Every code change must be traceable via a branch and Pull Request. No direct com
 <instructions>
 
 <step number="1" name="Identify or Create Tracking Issue">
-Ensure there is a corresponding VCS work item. If none exists, create one via `vcs_create_work_item`.
+First, check if a Tracking Issue already exists:
+- Look for a "## Tracking Issue" section in your prompt header — it contains the pre-created Issue number
+- Check the `OPTIMUS_TRACKING_ISSUE` environment variable
+If a Tracking Issue exists, use it. Do NOT create a duplicate.
+If none exists, create one via `vcs_create_work_item`.
 Capture the Issue ID (e.g., `#113`). Do not proceed without one.
 </step>
 

--- a/src/mcp/council-runner.ts
+++ b/src/mcp/council-runner.ts
@@ -93,7 +93,8 @@ export async function runAsyncWorker(taskId: string, workspacePath: string) {
                     requiredSkills: task.required_skills
                 },
                 parentDepth,
-                parentIssueNumber
+                parentIssueNumber,
+                task.github_issue_number  // auto-created tracking issue
             );
         } else if (task.type === 'dispatch_council') {
             await dispatchCouncilConcurrent(


### PR DESCRIPTION
## Summary

Prevents agents from creating duplicate GitHub Issues when a tracking issue was already auto-created by the system during async delegation.

### Changes

**Change 1** (`src/mcp/worker-spawner.ts`) — Already on master via #161 merge:
- Added `autoIssueNumber?: number` param to `delegateTaskSingle()`
- Injects `## Tracking Issue` header into agent prompt when `autoIssueNumber` is set
- Sets `OPTIMUS_TRACKING_ISSUE` env var for child agents

**Change 2** (`src/mcp/council-runner.ts`):
- Passes `task.github_issue_number` as `autoIssueNumber` to `delegateTaskSingle()` in async delegation path

**Change 3** (`optimus-plugin/skills/feature-dev/SKILL.md`):
- Added "Pre-Existing Tracking Issue" section after Phase 1 to instruct PM agents to check for existing tracking issues before creating new ones

**Change 4** (`optimus-plugin/skills/git-workflow/SKILL.md`):
- Updated Step 1 to check for pre-existing tracking issues before creating new VCS work items

### Verification
- `npm run build` passes with zero errors

Fixes #166