### PR TITLE
[Optimus] fix: preserve user config during optimus upgrade, fixes #175

### DIFF
--- a/optimus-plugin/bin/commands/upgrade.js
+++ b/optimus-plugin/bin/commands/upgrade.js
@@ -8,6 +8,55 @@
 const fs = require('fs');
 const path = require('path');
 
+function deepMergePreserveUser(template, user) {
+  const result = { ...template };
+  for (const key of Object.keys(user)) {
+    if (typeof user[key] === 'object' && user[key] !== null && !Array.isArray(user[key])
+        && typeof result[key] === 'object' && result[key] !== null && !Array.isArray(result[key])) {
+      result[key] = deepMergePreserveUser(result[key], user[key]);
+    } else {
+      result[key] = user[key];
+    }
+  }
+  return result;
+}
+
+function mergeConfigFiles(srcDir, destDir) {
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+  }
+  const entries = fs.readdirSync(srcDir, { withFileTypes: true });
+  let count = 0;
+  for (const entry of entries) {
+    const srcPath = path.join(srcDir, entry.name);
+    const destPath = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      count += mergeConfigFiles(srcPath, destPath);
+    } else if (entry.name.endsWith('.json') && fs.existsSync(destPath)) {
+      try {
+        const template = JSON.parse(fs.readFileSync(srcPath, 'utf8'));
+        const user = JSON.parse(fs.readFileSync(destPath, 'utf8'));
+        const merged = deepMergePreserveUser(template, user);
+        fs.writeFileSync(destPath, JSON.stringify(merged, null, 2), 'utf8');
+        if (JSON.stringify(merged) !== JSON.stringify(template)) {
+          console.log(`  ℹ️  ${entry.name}: preserved your existing config (organization, project, etc.)`);
+        } else {
+          console.log(`  🔄 Updated ${path.relative(process.cwd(), destPath)}`);
+        }
+      } catch (e) {
+        fs.copyFileSync(srcPath, destPath);
+        console.log(`  🔄 Updated ${path.relative(process.cwd(), destPath)} (overwritten — parse error)`);
+      }
+      count++;
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+      console.log(`  🔄 Updated ${path.relative(process.cwd(), destPath)}`);
+      count++;
+    }
+  }
+  return count;
+}
+
 function copyDirForceOverwrite(src, dest) {
   if (!fs.existsSync(dest)) {
     fs.mkdirSync(dest, { recursive: true });
@@ -63,11 +112,11 @@ module.exports = function upgrade() {
     roleCount = copyDirForceOverwrite(rolesSrc, path.join(optimusDir, 'roles'));
   }
 
-  // 3. Config: FORCE OVERWRITE
+  // 3. Config: MERGE (preserve user values in JSON files)
   const configSrc = path.join(scaffoldDir, 'config');
   if (fs.existsSync(configSrc)) {
     console.log('\n⚙️  Upgrading system config...');
-    configCount = copyDirForceOverwrite(configSrc, path.join(optimusDir, 'config'));
+    configCount = mergeConfigFiles(configSrc, path.join(optimusDir, 'config'));
   }
 
   // 4. Agents: NEVER TOUCH

--- a/src/adapters/vcs/VcsProviderFactory.ts
+++ b/src/adapters/vcs/VcsProviderFactory.ts
@@ -1,6 +1,7 @@
 import { IVcsProvider } from './IVcsProvider';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as crypto from 'crypto';
 import { execSync } from 'child_process';
 
 export interface VcsConfig {
@@ -33,6 +34,7 @@ export interface VcsConfig {
 export class VcsProviderFactory {
     private static cachedProvider: IVcsProvider | null = null;
     private static cachedConfigPath: string | null = null;
+    private static cachedConfigHash: string | null = null;
 
     /**
      * Get the appropriate VCS provider for the workspace
@@ -43,9 +45,11 @@ export class VcsProviderFactory {
     public static async getProvider(workspacePath?: string): Promise<IVcsProvider> {
         const resolvedWorkspacePath = workspacePath || process.cwd();
 
-        // Return cached provider if available and workspace hasn't changed
+        // Return cached provider if available and config hasn't changed
         const configPath = this.getConfigPath(resolvedWorkspacePath);
-        if (this.cachedProvider && this.cachedConfigPath === configPath) {
+        const configContent = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : '';
+        const configHash = crypto.createHash('md5').update(configContent).digest('hex');
+        if (this.cachedProvider && this.cachedConfigPath === configPath && this.cachedConfigHash === configHash) {
             return this.cachedProvider;
         }
 
@@ -74,9 +78,10 @@ export class VcsProviderFactory {
             throw new Error(`Unsupported or undetectable VCS provider: ${providerType}`);
         }
 
-        // Cache the provider and config path
+        // Cache the provider, config path, and hash
         this.cachedProvider = provider;
         this.cachedConfigPath = configPath;
+        this.cachedConfigHash = configHash;
 
         return provider;
     }
@@ -87,6 +92,7 @@ export class VcsProviderFactory {
     public static clearCache(): void {
         this.cachedProvider = null;
         this.cachedConfigPath = null;
+        this.cachedConfigHash = null;
     }
 
     private static getConfigPath(workspacePath: string): string {
@@ -161,7 +167,10 @@ export class VcsProviderFactory {
 
             throw new Error('Unable to parse GitHub repository info from remote URL');
         } catch (error: any) {
-            throw new Error(`Failed to determine GitHub repository info: ${error.message}`);
+            throw new Error(
+                'Failed to auto-detect GitHub info: git not found in PATH or not a git repository. ' +
+                'Set "owner" and "repo" explicitly in .optimus/config/vcs.json'
+            );
         }
     }
 
@@ -202,7 +211,10 @@ export class VcsProviderFactory {
 
             throw new Error('Unable to parse Azure DevOps repository info from remote URL');
         } catch (error: any) {
-            throw new Error(`Failed to determine Azure DevOps repository info: ${error.message}`);
+            throw new Error(
+                'Failed to auto-detect Azure DevOps info: git not found in PATH or not a git repository. ' +
+                'Set "organization" and "project" explicitly in .optimus/config/vcs.json'
+            );
         }
     }
 


### PR DESCRIPTION
## P0 Bug Fix: `optimus upgrade` wipes vcs.json user config

### Problem
`optimus upgrade` force-overwrites all config files including `vcs.json`, wiping user-configured ADO `organization` and `project`. This breaks ALL `vcs_create_work_item` calls for ADO users. The static provider cache then persists the broken state until VS Code restart.

### Fixes (all 4 implemented)

**Fix 1 (Critical):** Deep merge config during upgrade — `deepMergePreserveUser()` + `mergeConfigFiles()`
**Fix 2 (Important):** Config-aware cache invalidation — MD5 hash comparison in `VcsProviderFactory`
**Fix 3 (Defensive):** Clear error when git auto-detect fails — actionable messages in catch blocks
**Fix 4 (UX):** Preservation warning during upgrade — `ℹ️ vcs.json: preserved your existing config`

### Files Changed
- `optimus-plugin/bin/commands/upgrade.js`
- `src/adapters/vcs/VcsProviderFactory.ts`

Fixes #175

---
_🤖 Created by `product-manager` via Optimus Spartan Swarm_