### PR TITLE
[Optimus] docs: add systemic safeguards from vcs.json wipe postmortem

### DIFF
--- a/.optimus/config/system-instructions.md
+++ b/.optimus/config/system-instructions.md
@@ -120,6 +120,27 @@ The system automatically injects `OPTIMUS_PARENT_ISSUE` into child agent process
 ## VCS Auto-Tagging
 All Work Items and PRs created via MCP tools are automatically tagged with `[Optimus]` prefix and `optimus-bot` label for traceability across both GitHub and Azure DevOps platforms.
 
+## Engineering Safety Rules
+
+### Cache Invalidation
+Any code that caches configuration read from disk (e.g., VCS provider, agent config) MUST have a cache invalidation mechanism. Either:
+- TTL-based expiry
+- File content hash comparison on access
+- Manual invalidation on config write
+
+### No Silent Error Swallowing
+Never catch an exception and return a default/empty value without logging. At minimum:
+- `console.error()` the original error message
+- Include context about what operation failed and what the user should check
+- Prefer actionable error messages: "Auto-detect failed: git not found in PATH. Set organization and project in .optimus/config/vcs.json"
+
+### Merge-First for Config Overwrites
+Any operation that writes to user-editable config files (vcs.json, available-agents.json, etc.) MUST:
+1. Read existing file first
+2. Deep-merge new values with existing (user values take priority)
+3. Only ADD new fields, never DELETE or OVERWRITE existing user values
+4. Log what was preserved vs what was added
+
 ---
 
 # Part 2: Project-Specific Constraints (Optimus Code Repository)

--- a/.optimus/memory/continuous-memory.md
+++ b/.optimus/memory/continuous-memory.md
@@ -1,0 +1,35 @@
+---
+id: mem_1773295993057_419
+category: feature-completion
+tags: [write_blackboard_artifact, mcp-tool, security, symlink, plan-mode]
+created: 2026-03-12T06:13:13.056Z
+---
+## write_blackboard_artifact MCP Tool — Completed 2026-03-12
+
+Merged as `87b767e` on master (PR #123, Issue #121).
+
+Enables plan-mode agents to write files to `.optimus/` only. Two-layer security:
+1. Lexical `startsWith(optimusRoot + path.sep)` — prevents `..` and sibling bypass
+2. `fs.realpathSync()` on existing path prefix — prevents symlink traversal
+
+Key lesson: `path.resolve()` and `path.normalize()` do NOT resolve symlinks. Always use `fs.realpathSync()` when validating paths against symlink-based escapes. The reviewer caught this as P0 — the initial implementation only had the lexical check.
+
+Content validation uses `=== undefined || === null` (not `!content`) to allow empty strings.
+
+---
+id: mem_vcs_json_wipe_20260312
+category: bug-postmortem
+tags: [upgrade, config-wipe, vcs.json, ado, cache-invalidation]
+created: 2026-03-12
+---
+## vcs.json Config Wipe Bug — Postmortem 2026-03-12
+
+`optimus upgrade` force-overwrote `.optimus/config/vcs.json`, wiping user's ADO organization and project values.
+Root causes: (1) upgrade used overwrite instead of merge (2) AdoProvider static cache prevented recovery (3) git-not-in-PATH error was silently swallowed.
+
+Lessons:
+- ALWAYS deep-merge user config files during upgrade, never overwrite
+- Static caches of disk-read config MUST have invalidation
+- Never swallow errors from `execSync` — provide actionable fallback messages
+- Test upgrade paths with real user data, not empty directories
+

--- a/.optimus/roles/qa-engineer.md
+++ b/.optimus/roles/qa-engineer.md
@@ -21,3 +21,9 @@ Your sole objective is: **To find flaws, falsify assumptions, and ensure all cod
 - Never try to fix the business logic code yourself; your job is to "break things" and "uncover bugs".
 - Test cases must be 100% reproducible.
 - If prerequisites are missing, state in the report: "Dependencies are not ready, unable to test."
+
+### Config Preservation Verification
+For ANY PR that modifies `init.js`, `upgrade.js`, or any code that writes to `.optimus/config/`:
+- Verify that running `optimus upgrade` on a workspace with customized vcs.json preserves all user values
+- Verify that running `optimus init` on an existing workspace does not overwrite user config
+- Flag as P0 blocker if user config is destroyed

--- a/optimus-plugin/scaffold/config/system-instructions.md
+++ b/optimus-plugin/scaffold/config/system-instructions.md
@@ -120,6 +120,27 @@ The system automatically injects `OPTIMUS_PARENT_ISSUE` into child agent process
 ## GitHub Auto-Tagging
 All Issues and PRs created via MCP tools are automatically tagged with `[Optimus]` prefix and `optimus-bot` label for traceability.
 
+## Engineering Safety Rules
+
+### Cache Invalidation
+Any code that caches configuration read from disk (e.g., VCS provider, agent config) MUST have a cache invalidation mechanism. Either:
+- TTL-based expiry
+- File content hash comparison on access
+- Manual invalidation on config write
+
+### No Silent Error Swallowing
+Never catch an exception and return a default/empty value without logging. At minimum:
+- `console.error()` the original error message
+- Include context about what operation failed and what the user should check
+- Prefer actionable error messages: "Auto-detect failed: git not found in PATH. Set organization and project in .optimus/config/vcs.json"
+
+### Merge-First for Config Overwrites
+Any operation that writes to user-editable config files (vcs.json, available-agents.json, etc.) MUST:
+1. Read existing file first
+2. Deep-merge new values with existing (user values take priority)
+3. Only ADD new fields, never DELETE or OVERWRITE existing user values
+4. Log what was preserved vs what was added
+
 ---
 
 # Part 2: Project-Specific Constraints (Optimus Code Repository)

--- a/optimus-plugin/skills/feature-dev/SKILL.md
+++ b/optimus-plugin/skills/feature-dev/SKILL.md
@@ -218,6 +218,13 @@ PM reads all reviews and ranks issues by severity:
 - **Critical issues found** → PM delegates back to dev for fixes, then re-reviews
 - **Clean** → PM merges the PR via `vcs_merge_pr`
 
+### Destructive Edge Case Testing (MANDATORY for file operations)
+Any feature that involves file overwrite, delete, migrate, or upgrade MUST include edge case tests with:
+- A target directory containing user-customized config files (not empty defaults)
+- Verification that user values survive the operation
+- Test both "first install" (empty target) AND "upgrade" (existing data) scenarios
+Example: `optimus upgrade` must be tested against a `.optimus/config/vcs.json` with real org/project values.
+
 ---
 
 ## Phase 6: Summary


### PR DESCRIPTION
## Summary

Hardens system documentation and processes at 4 levels to prevent future config-wipe bugs like the vcs.json incident (#175).

### Changes (5 markdown file edits, no code)

1. **`optimus-plugin/skills/feature-dev/SKILL.md`** — Added "Destructive Edge Case Testing" mandate between Phase 5 and Phase 6
2. **`.optimus/config/system-instructions.md`** — Added "Engineering Safety Rules" section (Cache Invalidation, No Silent Error Swallowing, Merge-First for Config Overwrites)
3. **`optimus-plugin/scaffold/config/system-instructions.md`** — Same Engineering Safety Rules (ships to end-users)
4. **`.optimus/memory/continuous-memory.md`** — Appended vcs.json wipe postmortem entry
5. **`.optimus/roles/qa-engineer.md`** — Added Config Preservation Verification mandate

Fixes #178

---
_🤖 Created by `senior-full-stack-builder` via Optimus Spartan Swarm_