### PR TITLE
[Optimus] feat: default to squash merge and sync local master after merge

### DIFF
--- a/src/adapters/vcs/AdoProvider.ts
+++ b/src/adapters/vcs/AdoProvider.ts
@@ -203,7 +203,7 @@ export class AdoProvider implements IVcsProvider {
     async mergePullRequest(
         pullRequestId: string | number,
         commitTitle?: string,
-        mergeMethod: 'merge' | 'squash' | 'rebase' = 'merge'
+        mergeMethod: 'merge' | 'squash' | 'rebase' = 'squash'
     ): Promise<MergeResult> {
         const token = this.getToken();
         if (!token) {

--- a/src/adapters/vcs/GitHubProvider.ts
+++ b/src/adapters/vcs/GitHubProvider.ts
@@ -134,7 +134,7 @@ export class GitHubProvider implements IVcsProvider {
     async mergePullRequest(
         pullRequestId: string | number,
         commitTitle?: string,
-        mergeMethod: 'merge' | 'squash' | 'rebase' = 'merge'
+        mergeMethod: 'merge' | 'squash' | 'rebase' = 'squash'
     ): Promise<MergeResult> {
         const token = this.getToken();
         if (!token) {

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -985,10 +985,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
       }
 
+      // Post-merge: sync local master with remote
+      let syncMsg = '';
+      try {
+        const syncBranch = result.baseBranch || 'master';
+        const currentBranchAfterCleanup = execSync('git rev-parse --abbrev-ref HEAD', { cwd: workspace_path, encoding: 'utf8' }).trim();
+        if (currentBranchAfterCleanup !== syncBranch) {
+          execSync(`git checkout ${syncBranch}`, { cwd: workspace_path, encoding: 'utf8' });
+        }
+        execSync(`git pull origin ${syncBranch}`, { cwd: workspace_path, encoding: 'utf8' });
+        syncMsg = ` Local '${syncBranch}' synced.`;
+      } catch (syncErr: any) {
+        console.error(`[Post-Merge Sync] Warning: ${syncErr.message}`);
+      }
+
       return {
         content: [{
           type: "text",
-          text: `✅ Pull request #${pull_request_id} merged successfully on ${vcsProvider.getProviderName()}.${branchCleanupMsg}`
+          text: `✅ Pull request #${pull_request_id} merged successfully on ${vcsProvider.getProviderName()}.${branchCleanupMsg}${syncMsg}`
         }]
       };
     } catch (error: any) {


### PR DESCRIPTION
## Summary

Changes the default merge strategy from `merge` to `squash` in both VCS providers and adds automatic local `git pull` sync after merging a PR.

### Changes

1. **`src/adapters/vcs/GitHubProvider.ts`** — Default `mergeMethod` parameter changed from `'merge'` to `'squash'`
2. **`src/adapters/vcs/AdoProvider.ts`** — Same default parameter change from `'merge'` to `'squash'`
3. **`src/mcp/mcp-server.ts`** — Added post-merge `git pull` sync block after branch cleanup in `vcs_merge_pr` handler. Checks out the base branch if needed and pulls to keep local in sync with remote after squash merge.

### Build

`npm run build` passes with 0 errors (237.5kb bundle).

Fixes #185

---
_🤖 Created by `senior-full-stack-builder` via Optimus Spartan Swarm_