### PR TITLE
[Optimus] feat: add health log reporting to daily-ops patrol

### DIFF
--- a/.optimus/skills/daily-ops/SKILL.md
+++ b/.optimus/skills/daily-ops/SKILL.md
@@ -99,6 +99,19 @@ Write a patrol report to `.optimus/reports/daily-ops-<YYYY-MM-DD>.md` with:
 - Items deferred (over budget or report-only)
 - Recommendations for human review
 
+### Phase 5: Health Log Update
+After writing the local patrol report, post a brief one-line summary as a comment on the System Health Log Issue.
+
+1. Read the Health Log Issue number from `.optimus/system/meta-crontab.json` field `health_log_issue`
+2. If the field is missing or `null`, skip this phase (Health Log not configured)
+3. Compose a one-line summary in one of these formats:
+   - `✅ All clear. [actions taken summary]` — no findings or only Info-level items
+   - `⚠️ [findings summary]. [actions taken]` — Low/Medium findings with actions taken
+   - `🔴 [critical findings]` — High severity findings (e.g., unreleased P0)
+4. Post via `vcs_add_comment` with `item_type: "workitem"`, `item_id: <health_log_issue>`, and the summary as `comment`
+
+In Dry-Run mode, still post to the health log but prefix the comment with `DRY RUN: `.
+
 ## Dry-Run Mode
 If Meta-Cron indicates this is a dry-run (first 3 runs), execute Phases 1-2 only. Write the report with "DRY RUN" prefix. Do NOT take any actions.
 

--- a/.optimus/system/meta-crontab.json
+++ b/.optimus/system/meta-crontab.json
@@ -1,5 +1,6 @@
 {
   "max_concurrent": 3,
+  "health_log_issue": 300,
   "crons": [
     {
       "id": "hourly-steward",

--- a/optimus-plugin/scaffold/system/meta-crontab.json
+++ b/optimus-plugin/scaffold/system/meta-crontab.json
@@ -1,11 +1,14 @@
 {
   "max_concurrent": 3,
+  "health_log_issue": null,
   "crons": [
     {
       "id": "night-steward",
       "cron_expression": "0 2 * * *",
       "role": "system-steward",
-      "required_skills": ["daily-ops"],
+      "required_skills": [
+        "daily-ops"
+      ],
       "capability_tier": "maintain",
       "concurrency_policy": "Forbid",
       "max_actions": 5,

--- a/optimus-plugin/skills/daily-ops/SKILL.md
+++ b/optimus-plugin/skills/daily-ops/SKILL.md
@@ -99,6 +99,19 @@ Write a patrol report to `.optimus/reports/daily-ops-<YYYY-MM-DD>.md` with:
 - Items deferred (over budget or report-only)
 - Recommendations for human review
 
+### Phase 5: Health Log Update
+After writing the local patrol report, post a brief one-line summary as a comment on the System Health Log Issue.
+
+1. Read the Health Log Issue number from `.optimus/system/meta-crontab.json` field `health_log_issue`
+2. If the field is missing or `null`, skip this phase (Health Log not configured)
+3. Compose a one-line summary in one of these formats:
+   - `✅ All clear. [actions taken summary]` — no findings or only Info-level items
+   - `⚠️ [findings summary]. [actions taken]` — Low/Medium findings with actions taken
+   - `🔴 [critical findings]` — High severity findings (e.g., unreleased P0)
+4. Post via `vcs_add_comment` with `item_type: "workitem"`, `item_id: <health_log_issue>`, and the summary as `comment`
+
+In Dry-Run mode, still post to the health log but prefix the comment with `DRY RUN: `.
+
 ## Dry-Run Mode
 If Meta-Cron indicates this is a dry-run (first 3 runs), execute Phases 1-2 only. Write the report with "DRY RUN" prefix. Do NOT take any actions.
 


### PR DESCRIPTION
## Summary

Adds health log reporting capability to the daily-ops patrol skill so the system steward posts a brief summary to the System Health Log Issue (#300) after each patrol.

### Changes:
- **SKILL.md** (both `.optimus/skills/daily-ops/` and `optimus-plugin/skills/daily-ops/`): Added Phase 5 (Health Log Update) section after Phase 4 (Report), before Dry-Run Mode
- **`.optimus/system/meta-crontab.json`**: Added `health_log_issue: 300` top-level field
- **`optimus-plugin/scaffold/system/meta-crontab.json`**: Added `health_log_issue: null` top-level field (unconfigured default for new projects)

Fixes #299

---
🤖 Generated by senior-full-stack-builder agent

---
_🤖 Created by `senior-full-stack-builder` via Optimus Spartan Swarm_