### PR TITLE
[Optimus] fix: address review blockers for engine health tracking, fixes #305

### DIFF
--- a/src/mcp/worker-spawner.ts
+++ b/src/mcp/worker-spawner.ts
@@ -156,8 +156,16 @@ function saveEngineHealth(workspacePath: string, health: Record<string, EngineHe
     const dir = path.dirname(healthPath);
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
     const tmpPath = healthPath + '.tmp.' + process.pid;
-    fs.writeFileSync(tmpPath, JSON.stringify(health, null, 2), 'utf8');
-    fs.renameSync(tmpPath, healthPath);
+    try {
+        fs.writeFileSync(tmpPath, JSON.stringify(health, null, 2), 'utf8');
+        // Windows-safe atomic replace: unlink target first, then rename
+        try { fs.unlinkSync(healthPath); } catch (e: any) { if (e.code !== 'ENOENT') throw e; }
+        fs.renameSync(tmpPath, healthPath);
+    } catch (err: any) {
+        // Clean up temp file on failure
+        try { fs.unlinkSync(tmpPath); } catch (_) {}
+        throw err;
+    }
 }
 
 function computeHealthStatus(consecutiveFailures: number): 'healthy' | 'degraded' | 'unhealthy' {
@@ -200,7 +208,9 @@ function trackEngineHealth(workspacePath: string, engine: string, model: string,
             console.error(`[EngineHealth] ${engine}/${model} status transition: ${oldStatus} → ${entry.status} (consecutive_failures=${entry.consecutive_failures})`);
         }
         saveEngineHealth(workspacePath, health);
-    }).catch(() => {});
+    }).catch((err: any) => {
+        console.error(`[EngineHealth] Failed to update engine health for ${engine}:${model}: ${err.message}`);
+    });
 }
 
 function resolveHealthyModel(workspacePath: string, engine: string, model: string): { engine: string; model: string } {


### PR DESCRIPTION
## Summary

Addresses 2 blocking issues from the code review of the engine health tracking feature (PR #307).

- **B1**: Replace bare `fs.renameSync` in `saveEngineHealth` with a Windows-safe unlink-then-rename pattern to prevent `EPERM` when another process holds a read handle on the target file
- **B2**: Replace silent `.catch(() => {})` in `trackEngineHealth` with proper `console.error` logging per the module's error message contract

Fixes #305

## Test Results

**Build**: `npm run build` — zero errors
```
  dist\mcp-server.js      287.8kb
  dist\mcp-server.js.map  185.1kb
Done in 41ms
✅ Plugin build complete (185.1 KB)
```

**Diff stat**:
```
 src/mcp/worker-spawner.ts | 16 +++++++++++++---
 1 file changed, 13 insertions(+), 3 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_🤖 Created by `senior-full-stack-builder` via Optimus Spartan Swarm_