### PR TITLE
[Optimus] fix: create IDE instruction files if missing during init/upgrade

### DIFF
--- a/optimus-plugin/bin/commands/init.js
+++ b/optimus-plugin/bin/commands/init.js
@@ -155,56 +155,21 @@ module.exports = function init() {
     }
   }
 
-  // 5. Inject reference into existing AI client instruction files (do NOT create new ones)
-  // Single source of truth: .optimus/config/system-instructions.md (also served via MCP Resource)
-  const injectMarker = '<!-- optimus-instructions -->';
-  const injectBlock = [
-    injectMarker,
-    '<!-- Auto-injected by optimus init — DO NOT EDIT this block -->',
-    '## Optimus Swarm Instructions',
-    '',
-    'This project uses the [Optimus Spartan Swarm](https://github.com/cloga/optimus-code) multi-agent orchestrator.',
-    'System instructions are maintained in `.optimus/config/system-instructions.md` and served via MCP Resource `optimus://system/instructions`.',
-    '',
-    'Please read and follow `.optimus/config/system-instructions.md` for all workflow protocols.',
-    '<!-- /optimus-instructions -->',
-  ].join('\n');
+  // 5. Inject system-instructions reference into IDE client config files
+  const { injectSystemInstructions } = require('../lib/inject');
+  const injectResult = injectSystemInstructions(cwd);
 
-  let injected = [];
-
-  // Claude Code: CLAUDE.md (only if it already exists)
-  const claudeMdPath = path.join(cwd, 'CLAUDE.md');
-  if (fs.existsSync(claudeMdPath)) {
-    const existing = fs.readFileSync(claudeMdPath, 'utf8');
-    if (!existing.includes(injectMarker)) {
-      fs.appendFileSync(claudeMdPath, '\n\n' + injectBlock + '\n');
-      injected.push('CLAUDE.md');
-    }
+  if (injectResult.created.length > 0) {
+    console.log('\n📝 Created IDE instruction files with Optimus reference:');
+    for (const f of injectResult.created) console.log(`  + ${f}`);
   }
-
-  // GitHub Copilot: .github/copilot-instructions.md (only if it already exists)
-  const copilotPath = path.join(cwd, '.github', 'copilot-instructions.md');
-  if (fs.existsSync(copilotPath)) {
-    const existing = fs.readFileSync(copilotPath, 'utf8');
-    if (!existing.includes(injectMarker)) {
-      fs.appendFileSync(copilotPath, '\n\n' + injectBlock + '\n');
-      injected.push('.github/copilot-instructions.md');
-    }
+  if (injectResult.injected.length > 0) {
+    console.log('\n🔗 Injected Optimus reference into existing files:');
+    for (const f of injectResult.injected) console.log(`  → ${f}`);
   }
-
-  // Cursor: .cursor/rules/ (only if directory already exists)
-  const cursorRulesDir = path.join(cwd, '.cursor', 'rules');
-  if (fs.existsSync(cursorRulesDir)) {
-    const cursorRulePath = path.join(cursorRulesDir, 'optimus.mdc');
-    if (!fs.existsSync(cursorRulePath)) {
-      fs.writeFileSync(cursorRulePath, injectBlock + '\n', 'utf8');
-      injected.push('.cursor/rules/optimus.mdc');
-    }
-  }
-
-  if (injected.length > 0) {
-    console.log('\n🔗 Injected Optimus reference into existing client config(s):');
-    for (const f of injected) console.log(`  → ${f}`);
+  if (injectResult.skipped.length > 0) {
+    console.log('\n⏭️  Already configured:');
+    for (const f of injectResult.skipped) console.log(`  ✓ ${f}`);
   }
 
   console.log('\n✅ Workspace initialized! Your .optimus/ directory is ready.');

--- a/optimus-plugin/bin/commands/upgrade.js
+++ b/optimus-plugin/bin/commands/upgrade.js
@@ -188,7 +188,20 @@ module.exports = function upgrade() {
   }
   console.log(`   📍 MCP server path: ${distPath}`);
 
-  // 7. Summary
+  // 7. Ensure system-instructions references exist in IDE instruction files
+  const { injectSystemInstructions } = require('../lib/inject');
+  const injectResult = injectSystemInstructions(cwd);
+
+  if (injectResult.created.length > 0) {
+    console.log('\n📝 Created missing IDE instruction files:');
+    for (const f of injectResult.created) console.log(`  + ${f}`);
+  }
+  if (injectResult.injected.length > 0) {
+    console.log('\n🔗 Fixed missing Optimus reference in:');
+    for (const f of injectResult.injected) console.log(`  → ${f}`);
+  }
+
+  // 8. Summary
   console.log(`\n✅ Upgrade complete: ${skillCount} skills, ${roleCount} roles, ${configCount} config files updated.`);
   console.log('   User agents and runtime data preserved.\n');
 };

--- a/optimus-plugin/bin/lib/inject.js
+++ b/optimus-plugin/bin/lib/inject.js
@@ -1,0 +1,72 @@
+/**
+ * Shared system-instructions injection logic.
+ * Used by both `optimus init` and `optimus upgrade` to ensure IDE instruction
+ * files reference `.optimus/config/system-instructions.md`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const injectMarker = '<!-- optimus-instructions -->';
+const injectBlock = [
+  injectMarker,
+  '<!-- Auto-injected by optimus init — DO NOT EDIT this block -->',
+  '## Optimus Swarm Instructions',
+  '',
+  'This project uses the [Optimus Spartan Swarm](https://github.com/cloga/optimus-code) multi-agent orchestrator.',
+  'System instructions are maintained in `.optimus/config/system-instructions.md` and served via MCP Resource `optimus://system/instructions`.',
+  '',
+  'Please read and follow `.optimus/config/system-instructions.md` for all workflow protocols.',
+  '<!-- /optimus-instructions -->',
+].join('\n');
+
+/**
+ * Inject Optimus system-instructions reference into IDE instruction files.
+ * Creates files if they don't exist. Idempotent via marker check.
+ * @param {string} cwd - The project root directory
+ * @returns {{ created: string[], injected: string[], skipped: string[] }}
+ */
+function injectSystemInstructions(cwd) {
+  const created = [];
+  const injected = [];
+  const skipped = [];
+
+  /**
+   * Process a single target file.
+   * @param {string} relPath - Relative path from cwd (e.g. '.claude/CLAUDE.md')
+   * @param {boolean} createIfMissing - Whether to create the file if it doesn't exist
+   */
+  function processTarget(relPath, createIfMissing) {
+    const fullPath = path.join(cwd, relPath);
+    if (fs.existsSync(fullPath)) {
+      const existing = fs.readFileSync(fullPath, 'utf8');
+      if (existing.includes(injectMarker)) {
+        skipped.push(relPath);
+      } else {
+        fs.appendFileSync(fullPath, '\n\n' + injectBlock + '\n');
+        injected.push(relPath);
+      }
+    } else if (createIfMissing) {
+      const dir = path.dirname(fullPath);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(fullPath, injectBlock + '\n', 'utf8');
+      created.push(relPath);
+    }
+  }
+
+  // Claude Code (sequential):
+  // 1. .claude/CLAUDE.md — create if missing
+  processTarget('.claude/CLAUDE.md', true);
+  // 2. Root CLAUDE.md — NEVER create, only inject if it already exists
+  processTarget('CLAUDE.md', false);
+
+  // GitHub Copilot — create if missing
+  processTarget('.github/copilot-instructions.md', true);
+
+  // Cursor — create if missing
+  processTarget('.cursor/rules/optimus.mdc', true);
+
+  return { created, injected, skipped };
+}
+
+module.exports = { injectSystemInstructions };


### PR DESCRIPTION
## Summary

Fixes #308 — System instructions injection was silently failing when IDE instruction files didn't exist.

### Changes

- **Created `optimus-plugin/bin/lib/inject.js`**: Shared `injectSystemInstructions(cwd)` function that handles all IDE targets with create-if-missing semantics and idempotent marker checks.
- **Modified `init.js`**: Replaced inline Step 5 (lines 158-208) with a call to the shared function. Now creates `.claude/CLAUDE.md`, `.github/copilot-instructions.md`, and `.cursor/rules/optimus.mdc` if they don't exist instead of skipping.
- **Modified `upgrade.js`**: Added Step 7 (injection) before the summary, so upgrades from older versions also get the reference block.

### Bugs fixed

1. `init.js` only checked root `CLAUDE.md` — modern Claude Code uses `.claude/CLAUDE.md` (never checked)
2. `init.js` skipped injection entirely if IDE files didn't exist (silent failure)
3. `upgrade.js` had zero injection logic — users upgrading from older versions never got the reference

### Targets handled

| File | Create if missing? |
|------|--------------------|
| `.claude/CLAUDE.md` | YES |
| `CLAUDE.md` (root) | NO (append only) |
| `.github/copilot-instructions.md` | YES |
| `.cursor/rules/optimus.mdc` | YES |

---
_🤖 Created by `senior-full-stack-builder` via Optimus Spartan Swarm_