### PR TITLE
[Optimus] feat: improve onboarding cold start experience

### DIFF
--- a/optimus-plugin/bin/commands/init.js
+++ b/optimus-plugin/bin/commands/init.js
@@ -160,31 +160,42 @@ module.exports = function init() {
   const injectResult = injectSystemInstructions(cwd);
 
   if (injectResult.created.length > 0) {
-    console.log('\n📝 Created IDE instruction files with Optimus reference:');
+    console.log('\n📝 Created IDE instruction files:');
     for (const f of injectResult.created) console.log(`  + ${f}`);
   }
   if (injectResult.injected.length > 0) {
-    console.log('\n🔗 Injected Optimus reference into existing files:');
+    console.log('\n🔗 Injected Optimus instructions into existing files:');
     for (const f of injectResult.injected) console.log(`  → ${f}`);
+  }
+  if (injectResult.replaced.length > 0) {
+    console.log('\n🔄 Updated stale instruction blocks:');
+    for (const r of injectResult.replaced) {
+      const ver = r.from != null ? `(v${r.from} → v${r.to})` : '(updated)';
+      console.log(`  → ${r.path} ${ver}`);
+    }
   }
   if (injectResult.skipped.length > 0) {
     console.log('\n⏭️  Already configured:');
     for (const f of injectResult.skipped) console.log(`  ✓ ${f}`);
   }
+  if (injectResult.errors.length > 0) {
+    console.log('\n⚠️  Warnings:');
+    for (const e of injectResult.errors) console.log(`  ! ${e}`);
+  }
 
-  console.log('\n✅ Workspace initialized! Your .optimus/ directory is ready.');
-  console.log('   System instructions: .optimus/config/system-instructions.md (served via MCP Resource)');
-  console.log('   Run `optimus serve` or configure your MCP client to start.\n');
-
-  console.log('╔══════════════════════════════════════════════════════════════╗');
-  console.log('║  🚀 Try your first command!                                 ║');
-  console.log('║                                                              ║');
-  console.log('║  Paste this into your AI assistant (Copilot/Claude/Trae):    ║');
-  console.log('║                                                              ║');
-  console.log('║  "Run roster_check to see my AI team, then use the           ║');
-  console.log('║   feature-dev skill to help me build [your feature here]"    ║');
-  console.log('║                                                              ║');
-  console.log('║  📖 Docs: https://cloga.github.io/optimus-code              ║');
-  console.log('╚══════════════════════════════════════════════════════════════╝');
+  console.log('\n✅ Workspace initialized! Your AI development team is ready.');
+  console.log('\n📋 What happened:');
+  console.log('   • Created .optimus/ with agent roles, skills, and config');
+  console.log('   • Configured MCP server connection for your IDE');
+  console.log('   • Injected Optimus instructions into IDE config files');
+  console.log('\n🚀 Next steps:');
+  console.log('   1. Restart your IDE (or run "Developer: Reload Window" in VS Code)');
+  console.log('   2. Open your AI assistant and try one of these prompts:');
+  console.log('');
+  console.log('   💬 "Run roster_check to see what agents are available"');
+  console.log('   💬 "Help me build [your feature] — use the Optimus swarm to delegate the work"');
+  console.log('   💬 "Create a GitHub Issue for [task] and delegate it to the right specialist"');
+  console.log('');
+  console.log('   📖 Full protocol: .optimus/config/system-instructions.md');
   console.log('');
 };

--- a/optimus-plugin/bin/commands/upgrade.js
+++ b/optimus-plugin/bin/commands/upgrade.js
@@ -197,8 +197,19 @@ module.exports = function upgrade() {
     for (const f of injectResult.created) console.log(`  + ${f}`);
   }
   if (injectResult.injected.length > 0) {
-    console.log('\n🔗 Fixed missing Optimus reference in:');
+    console.log('\n🔗 Injected Optimus instructions into:');
     for (const f of injectResult.injected) console.log(`  → ${f}`);
+  }
+  if (injectResult.replaced.length > 0) {
+    console.log('\n🔄 Updated IDE instruction files with latest Optimus guidance:');
+    for (const r of injectResult.replaced) {
+      const ver = r.from != null ? `(v${r.from} → v${r.to})` : '(updated)';
+      console.log(`  → ${r.path} ${ver}`);
+    }
+  }
+  if (injectResult.errors.length > 0) {
+    console.log('\n⚠️  Injection warnings:');
+    for (const e of injectResult.errors) console.log(`  ! ${e}`);
   }
 
   // 8. Summary

--- a/optimus-plugin/bin/lib/inject.js
+++ b/optimus-plugin/bin/lib/inject.js
@@ -1,72 +1,193 @@
 /**
  * Shared system-instructions injection logic.
  * Used by both `optimus init` and `optimus upgrade` to ensure IDE instruction
- * files reference `.optimus/config/system-instructions.md`.
+ * files contain actionable Optimus guidance with version-aware replacement.
  */
 
 const fs = require('fs');
 const path = require('path');
 
-const injectMarker = '<!-- optimus-instructions -->';
-const injectBlock = [
-  injectMarker,
-  '<!-- Auto-injected by optimus init — DO NOT EDIT this block -->',
-  '## Optimus Swarm Instructions',
-  '',
-  'This project uses the [Optimus Spartan Swarm](https://github.com/cloga/optimus-code) multi-agent orchestrator.',
-  'System instructions are maintained in `.optimus/config/system-instructions.md` and served via MCP Resource `optimus://system/instructions`.',
-  '',
-  'Please read and follow `.optimus/config/system-instructions.md` for all workflow protocols.',
-  '<!-- /optimus-instructions -->',
-].join('\n');
+const OPEN_RE = /<!-- optimus-instructions v(\d+) -->/;
+const CLOSE_MARKER = '<!-- /optimus-instructions -->';
 
 /**
- * Inject Optimus system-instructions reference into IDE instruction files.
- * Creates files if they don't exist. Idempotent via marker check.
+ * Load instruction templates from scaffold/instructions/.
+ * @returns {{ defaultTemplate: string, defaultVersion: number, cursorTemplate: string }}
+ */
+function loadTemplates() {
+  const instrDir = path.resolve(__dirname, '..', '..', 'scaffold', 'instructions');
+  const defaultTemplate = fs.readFileSync(path.join(instrDir, 'default.md'), 'utf8');
+  const cursorTemplate = fs.readFileSync(path.join(instrDir, 'cursor.mdc'), 'utf8');
+
+  const match = defaultTemplate.match(OPEN_RE);
+  const defaultVersion = match ? parseInt(match[1], 10) : 1;
+
+  return { defaultTemplate, defaultVersion, cursorTemplate };
+}
+
+/**
+ * Apply version-aware block replacement to file content.
+ * @param {string} content - Existing file content
+ * @param {string} template - The template block to inject
+ * @param {number} templateVersion - Version number from the template
+ * @returns {{ content: string, action: 'replaced'|'injected'|'skipped', oldVersion?: number, warning?: string }}
+ */
+function applyVersionBlock(content, template, templateVersion) {
+  const openMatch = content.match(OPEN_RE);
+
+  if (!openMatch) {
+    // No markers found — append template
+    const trimmed = content.trimEnd();
+    const newContent = trimmed.length > 0
+      ? trimmed + '\n\n' + template.trimEnd() + '\n'
+      : template.trimEnd() + '\n';
+    return { content: newContent, action: 'injected' };
+  }
+
+  const existingVersion = parseInt(openMatch[1], 10);
+
+  if (existingVersion >= templateVersion) {
+    return { content, action: 'skipped' };
+  }
+
+  // Version is stale — replace the block
+  const openIdx = content.indexOf(openMatch[0]);
+  const closeIdx = content.indexOf(CLOSE_MARKER, openIdx);
+
+  if (closeIdx === -1) {
+    // Closing marker missing — skip and warn
+    return {
+      content,
+      action: 'skipped',
+      warning: 'Malformed block (missing closing marker) — skipped'
+    };
+  }
+
+  const before = content.substring(0, openIdx);
+  const after = content.substring(closeIdx + CLOSE_MARKER.length);
+  const newContent = before + template.trimEnd() + after;
+
+  return { content: newContent, action: 'replaced', oldVersion: existingVersion };
+}
+
+/**
+ * Inject Optimus system-instructions into IDE instruction files.
+ * Version-aware: replaces stale blocks, skips current ones, appends if missing.
  * @param {string} cwd - The project root directory
- * @returns {{ created: string[], injected: string[], skipped: string[] }}
+ * @returns {{ created: string[], injected: string[], replaced: Array<{path: string, from: number|null, to: number}>, skipped: string[], errors: string[] }}
  */
 function injectSystemInstructions(cwd) {
   const created = [];
   const injected = [];
+  const replaced = [];
   const skipped = [];
+  const errors = [];
+
+  // Validate cwd
+  try {
+    const stat = fs.statSync(cwd);
+    if (!stat.isDirectory()) {
+      errors.push('cwd is not a directory: ' + cwd);
+      return { created, injected, replaced, skipped, errors };
+    }
+  } catch (e) {
+    errors.push('cwd does not exist: ' + cwd);
+    return { created, injected, replaced, skipped, errors };
+  }
+
+  if (!fs.existsSync(path.join(cwd, '.optimus'))) {
+    errors.push('.optimus/ directory not found — has init been run?');
+    return { created, injected, replaced, skipped, errors };
+  }
+
+  var templates;
+  try {
+    templates = loadTemplates();
+  } catch (e) {
+    errors.push('Failed to load instruction templates: ' + e.message);
+    return { created, injected, replaced, skipped, errors };
+  }
+
+  var defaultTemplate = templates.defaultTemplate;
+  var defaultVersion = templates.defaultVersion;
+  var cursorTemplate = templates.cursorTemplate;
 
   /**
-   * Process a single target file.
-   * @param {string} relPath - Relative path from cwd (e.g. '.claude/CLAUDE.md')
-   * @param {boolean} createIfMissing - Whether to create the file if it doesn't exist
+   * Process a markdown target (Claude/Copilot) using default.md template.
+   * @param {string} relPath - Relative path from cwd
+   * @param {boolean} createIfMissing - Whether to create the file if absent
    */
-  function processTarget(relPath, createIfMissing) {
-    const fullPath = path.join(cwd, relPath);
-    if (fs.existsSync(fullPath)) {
-      const existing = fs.readFileSync(fullPath, 'utf8');
-      if (existing.includes(injectMarker)) {
-        skipped.push(relPath);
-      } else {
-        fs.appendFileSync(fullPath, '\n\n' + injectBlock + '\n');
-        injected.push(relPath);
+  function processMdTarget(relPath, createIfMissing) {
+    var fullPath = path.join(cwd, relPath);
+    try {
+      if (fs.existsSync(fullPath)) {
+        var existing = fs.readFileSync(fullPath, 'utf8');
+        var result = applyVersionBlock(existing, defaultTemplate, defaultVersion);
+
+        if (result.warning) {
+          errors.push(relPath + ': ' + result.warning);
+        }
+
+        if (result.action === 'replaced') {
+          fs.writeFileSync(fullPath, result.content, 'utf8');
+          replaced.push({ path: relPath, from: result.oldVersion, to: defaultVersion });
+        } else if (result.action === 'injected') {
+          fs.writeFileSync(fullPath, result.content, 'utf8');
+          injected.push(relPath);
+        } else {
+          skipped.push(relPath);
+        }
+      } else if (createIfMissing) {
+        var dir = path.dirname(fullPath);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(fullPath, defaultTemplate.trimEnd() + '\n', 'utf8');
+        created.push(relPath);
       }
-    } else if (createIfMissing) {
-      const dir = path.dirname(fullPath);
-      fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(fullPath, injectBlock + '\n', 'utf8');
-      created.push(relPath);
+    } catch (e) {
+      errors.push(relPath + ': ' + e.message);
     }
   }
 
-  // Claude Code (sequential):
-  // 1. .claude/CLAUDE.md — create if missing
-  processTarget('.claude/CLAUDE.md', true);
-  // 2. Root CLAUDE.md — NEVER create, only inject if it already exists
-  processTarget('CLAUDE.md', false);
+  /**
+   * Process the Cursor MDC target — Optimus owns this file entirely.
+   * @param {string} relPath - Relative path from cwd
+   */
+  function processCursorTarget(relPath) {
+    var fullPath = path.join(cwd, relPath);
+    try {
+      var dir = path.dirname(fullPath);
+      fs.mkdirSync(dir, { recursive: true });
+
+      if (fs.existsSync(fullPath)) {
+        var existing = fs.readFileSync(fullPath, 'utf8');
+        if (existing.trimEnd() === cursorTemplate.trimEnd()) {
+          skipped.push(relPath);
+        } else {
+          fs.writeFileSync(fullPath, cursorTemplate.trimEnd() + '\n', 'utf8');
+          replaced.push({ path: relPath, from: null, to: defaultVersion });
+        }
+      } else {
+        fs.writeFileSync(fullPath, cursorTemplate.trimEnd() + '\n', 'utf8');
+        created.push(relPath);
+      }
+    } catch (e) {
+      errors.push(relPath + ': ' + e.message);
+    }
+  }
+
+  // Claude Code: .claude/CLAUDE.md — create if missing
+  processMdTarget('.claude/CLAUDE.md', true);
+
+  // Root CLAUDE.md — append-only to existing, never create
+  processMdTarget('CLAUDE.md', false);
 
   // GitHub Copilot — create if missing
-  processTarget('.github/copilot-instructions.md', true);
+  processMdTarget('.github/copilot-instructions.md', true);
 
-  // Cursor — create if missing
-  processTarget('.cursor/rules/optimus.mdc', true);
+  // Cursor — create if missing, full file replace (Optimus-owned)
+  processCursorTarget('.cursor/rules/optimus.mdc');
 
-  return { created, injected, skipped };
+  return { created, injected, replaced, skipped, errors };
 }
 
 module.exports = { injectSystemInstructions };

--- a/optimus-plugin/scaffold/instructions/cursor.mdc
+++ b/optimus-plugin/scaffold/instructions/cursor.mdc
@@ -1,0 +1,26 @@
+---
+description: Optimus Swarm multi-agent orchestration instructions
+globs:
+alwaysApply: true
+---
+
+# Optimus Swarm — AI Development Team
+
+You have a multi-agent AI development team available via MCP tools (server: `spartan-swarm`).
+Instead of writing code directly, delegate to specialist agents who follow project conventions.
+
+## Key Tools
+- **`roster_check`** — List available agent roles and their capabilities
+- **`delegate_task`** — Assign a task to a specialist (e.g., `senior-full-stack-builder`, `code-architect`)
+- **`dispatch_council`** — Spawn parallel expert reviewers for architecture decisions
+
+## When to Delegate
+For any non-trivial task (multi-file changes, new features, bug investigations, refactors),
+call `roster_check` first to see available specialists, then delegate to the appropriate role.
+
+## Example Prompts
+- "Run roster_check to see what agents are available"
+- "Create a GitHub Issue for [task] and delegate it to the right specialist"
+- "Dispatch a council review for this architecture proposal"
+
+Full protocol: `.optimus/config/system-instructions.md`

--- a/optimus-plugin/scaffold/instructions/default.md
+++ b/optimus-plugin/scaffold/instructions/default.md
@@ -1,0 +1,24 @@
+<!-- optimus-instructions v1 -->
+<!-- Auto-managed by Optimus Swarm — edits between these markers will be overwritten on upgrade -->
+
+## Optimus Swarm — AI Development Team
+
+You have a multi-agent AI development team available via MCP tools (server: `spartan-swarm`).
+Instead of writing code directly, delegate to specialist agents who follow project conventions.
+
+### Key Tools
+- **`roster_check`** — List available agent roles and their capabilities
+- **`delegate_task`** — Assign a task to a specialist (e.g., `senior-full-stack-builder`, `code-architect`)
+- **`dispatch_council`** — Spawn parallel expert reviewers for architecture decisions
+
+### When to Delegate
+For any non-trivial task (multi-file changes, new features, bug investigations, refactors),
+call `roster_check` first to see available specialists, then delegate to the appropriate role.
+
+### Example Prompts
+- "Run roster_check to see what agents are available"
+- "Create a GitHub Issue for [task] and delegate it to the right specialist"
+- "Dispatch a council review for this architecture proposal"
+
+Full protocol: `.optimus/config/system-instructions.md`
+<!-- /optimus-instructions -->


### PR DESCRIPTION
## Summary

Fixes #313 — Improves the cold-start onboarding experience so that after `optimus init`, the Master Agent automatically uses Optimus delegation instead of writing code itself.

### Changes

- **New template files**: Created `optimus-plugin/scaffold/instructions/default.md` (versioned, ~20 lines) and `cursor.mdc` (MDC format) with actionable instructions for Claude/Copilot/Cursor
- **Rewritten `inject.js`**: Version-aware block replacement with `<!-- optimus-instructions v1 -->` markers, proper per-target processing (Claude, Copilot, Cursor, root CLAUDE.md), cwd validation, try/catch hardening, and structured return `{ created, injected, replaced, skipped, errors }`
- **Updated `init.js`**: Replaced box-drawing final output with actionable first-run guidance (what happened, next steps, example prompts, "restart your IDE" callout)
- **Updated `upgrade.js`**: Logs replaced instruction blocks with version transitions (e.g., `v1 → v2`)

### Test Plan

- [x] `npm run build` passes in `optimus-plugin/`
- [x] `require('./bin/lib/inject')` loads without errors
- [ ] Manual test: `optimus init` in a fresh directory shows new output
- [ ] Manual test: `optimus upgrade` with stale v0 markers shows replacement log
- [ ] Manual test: Cursor `.mdc` file is created correctly

---
_🤖 Created by `senior-full-stack-builder` via Optimus Spartan Swarm_