### PR TITLE
[Optimus] feat: cross-page navbar, terminal hero, and i18n for docs site

### DIFF
--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -45,7 +45,7 @@ a:hover{color:var(--accent)}
   padding:14px 24px;
 }
 .topnav-inner{
-  max-width:860px;margin:0 auto;
+  max-width:1100px;margin:0 auto;
   display:flex;align-items:center;justify-content:space-between;
 }
 .topnav-logo{font-weight:700;font-size:1rem;color:var(--text)}
@@ -177,6 +177,28 @@ footer{
 .footer-links a:hover{color:var(--accent)}
 .footer-tagline{color:var(--text-tertiary);font-size:.85rem;font-style:italic}
 
+/* ========== LANGUAGE TOGGLE (inline in navbar) ========== */
+.lang-toggle{
+  display:inline-flex;align-items:center;
+  background:var(--bg);border:1px solid var(--border);border-radius:6px;
+  overflow:hidden;margin-left:8px;
+}
+.lang-toggle:hover{border-color:var(--accent)}
+.lang-btn{
+  padding:5px 10px;font-size:.75rem;font-weight:600;
+  color:var(--text-tertiary);background:transparent;
+  border:none;cursor:pointer;transition:all .2s;
+  font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+}
+.lang-btn.active{color:#fff;background:var(--accent)}
+/* Hamburger */
+.hamburger{
+  display:none;background:none;border:1px solid var(--border);
+  border-radius:6px;padding:6px 8px;cursor:pointer;color:var(--text);line-height:0;
+}
+.hamburger:hover{border-color:var(--accent)}
+.hamburger svg{display:block}
+
 /* ========== RESPONSIVE ========== */
 @media(max-width:767px){
   .page-hero{padding:60px 16px 32px}
@@ -185,6 +207,15 @@ footer{
   .content pre{padding:14px 16px;font-size:.8rem}
   .content table{font-size:.82rem}
   .content th,.content td{padding:8px 10px}
+  /* Hamburger nav */
+  .topnav-links{
+    display:none;flex-direction:column;position:absolute;
+    top:100%;left:0;right:0;background:var(--surface);
+    border-bottom:1px solid var(--border);padding:16px 24px;gap:12px;
+  }
+  .topnav-links.open{display:flex}
+  .topnav-inner{position:relative}
+  .hamburger{display:block}
 }
 </style>
 </head>
@@ -194,37 +225,42 @@ footer{
 <nav class="topnav">
   <div class="topnav-inner">
     <a href="index.html" class="topnav-logo">Optimus Code</a>
-    <div class="topnav-links">
-      <a href="index.html">Home</a>
-      <a href="guide.html">Tutorial</a>
+    <button class="hamburger" id="hamburgerBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="topnav-links" id="navLinks">
+      <a href="guide.html" data-i18n="nav_tutorial">Tutorial</a>
       <a href="https://github.com/cloga/optimus-code" target="_blank" rel="noopener">GitHub</a>
-      <a href="https://github.com/cloga/optimus-code#readme" target="_blank" rel="noopener">Docs</a>
+      <div class="lang-toggle" id="langToggle" role="radiogroup" aria-label="Language selector">
+        <button class="lang-btn active" data-lang="en" role="radio" aria-checked="true">EN</button>
+        <button class="lang-btn" data-lang="zh" role="radio" aria-checked="false">中文</button>
+      </div>
     </div>
   </div>
 </nav>
 
 <!-- Page Hero -->
 <header class="page-hero">
-  <h1>Architecture Whitepaper</h1>
-  <p class="lead">A self-evolving multi-agent orchestration engine built on the Model Context Protocol.</p>
+  <h1 data-i18n="arch_hero_title">Architecture Whitepaper</h1>
+  <p class="lead" data-i18n="arch_hero_lead">A self-evolving multi-agent orchestration engine built on the Model Context Protocol.</p>
 </header>
 
 <!-- Table of Contents -->
 <div class="container">
   <nav class="toc">
-    <h2>Table of Contents</h2>
+    <h2 data-i18n="arch_toc_title">Table of Contents</h2>
     <ol>
-      <li><a href="#executive-summary">Executive Summary</a></li>
-      <li><a href="#the-great-unification">The Great Unification</a></li>
-      <li><a href="#self-evolving-agent-lifecycle">Self-Evolving Agent Lifecycle (T3&rarr;T2&rarr;T1)</a></li>
-      <li><a href="#the-spartan-swarm-protocol">The Spartan Swarm Protocol</a></li>
-      <li><a href="#council-pattern">Council Pattern (Map-Reduce)</a></li>
-      <li><a href="#skills-system">Skills System</a></li>
-      <li><a href="#plan-mode">Plan Mode &amp; Separation of Concerns</a></li>
-      <li><a href="#issue-first-sdlc">Issue-First SDLC</a></li>
-      <li><a href="#memory-reflection">Memory &amp; Reflection</a></li>
-      <li><a href="#autonomous-operations">Autonomous Operations</a></li>
-      <li><a href="#security-architecture">Security Architecture</a></li>
+      <li><a href="#executive-summary" data-i18n="arch_toc_1">Executive Summary</a></li>
+      <li><a href="#the-great-unification" data-i18n="arch_toc_2">The Great Unification</a></li>
+      <li><a href="#self-evolving-agent-lifecycle" data-i18n-html="arch_toc_3">Self-Evolving Agent Lifecycle (T3&rarr;T2&rarr;T1)</a></li>
+      <li><a href="#the-spartan-swarm-protocol" data-i18n="arch_toc_4">The Spartan Swarm Protocol</a></li>
+      <li><a href="#council-pattern" data-i18n="arch_toc_5">Council Pattern (Map-Reduce)</a></li>
+      <li><a href="#skills-system" data-i18n="arch_toc_6">Skills System</a></li>
+      <li><a href="#plan-mode" data-i18n-html="arch_toc_7">Plan Mode &amp; Separation of Concerns</a></li>
+      <li><a href="#issue-first-sdlc" data-i18n="arch_toc_8">Issue-First SDLC</a></li>
+      <li><a href="#memory-reflection" data-i18n-html="arch_toc_9">Memory &amp; Reflection</a></li>
+      <li><a href="#autonomous-operations" data-i18n="arch_toc_10">Autonomous Operations</a></li>
+      <li><a href="#security-architecture" data-i18n="arch_toc_11">Security Architecture</a></li>
     </ol>
   </nav>
 </div>
@@ -233,32 +269,32 @@ footer{
 <article class="container content">
 
 <!-- Section 1 -->
-<h2 id="executive-summary">1. Executive Summary</h2>
+<h2 id="executive-summary" data-i18n="arch_s1_title">1. Executive Summary</h2>
 
-<p>Optimus Code is a <strong>multi-agent orchestration engine</strong> that transforms any MCP-compatible AI coding tool into a coordinated development team. It works with VS Code (GitHub Copilot), Cursor, Windsurf, Claude Code, Goose, Roo Cline, and any other client that speaks the <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">Model Context Protocol</a>.</p>
+<p data-i18n-html="arch_s1_p1">Optimus Code is a <strong>multi-agent orchestration engine</strong> that transforms any MCP-compatible AI coding tool into a coordinated development team. It works with VS Code (GitHub Copilot), Cursor, Windsurf, Claude Code, Goose, Roo Cline, and any other client that speaks the <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">Model Context Protocol</a>.</p>
 
-<p>Rather than relying on a single AI assistant to handle every task &mdash; planning, coding, reviewing, testing &mdash; Optimus decomposes work across specialized agent roles: Product Manager, Architect, Developer, QA Engineer, and more. These agents are not preconfigured. They emerge dynamically as the system encounters new task types, evolve their role definitions through use, and accumulate project memory across sessions.</p>
+<p data-i18n-html="arch_s1_p2">Rather than relying on a single AI assistant to handle every task &mdash; planning, coding, reviewing, testing &mdash; Optimus decomposes work across specialized agent roles: Product Manager, Architect, Developer, QA Engineer, and more. These agents are not preconfigured. They emerge dynamically as the system encounters new task types, evolve their role definitions through use, and accumulate project memory across sessions.</p>
 
-<p>The result is a system where:</p>
+<p data-i18n="arch_s1_p3">The result is a system where:</p>
 <ul>
-  <li><strong>One natural-language prompt</strong> triggers a complete software development lifecycle (Issue &rarr; Branch &rarr; PR &rarr; Merge).</li>
-  <li><strong>Agents self-organize</strong> via a three-tier lifecycle: ephemeral workers precipitate into role templates, then freeze as reusable instances.</li>
-  <li><strong>Parallel expert councils</strong> debate architectural decisions using a map-reduce pattern before any code is written.</li>
-  <li><strong>Project memory</strong> ensures past mistakes and decisions persist, so the team improves with every task.</li>
+  <li data-i18n-html="arch_s1_li1"><strong>One natural-language prompt</strong> triggers a complete software development lifecycle (Issue &rarr; Branch &rarr; PR &rarr; Merge).</li>
+  <li data-i18n-html="arch_s1_li2"><strong>Agents self-organize</strong> via a three-tier lifecycle: ephemeral workers precipitate into role templates, then freeze as reusable instances.</li>
+  <li data-i18n-html="arch_s1_li3"><strong>Parallel expert councils</strong> debate architectural decisions using a map-reduce pattern before any code is written.</li>
+  <li data-i18n-html="arch_s1_li4"><strong>Project memory</strong> ensures past mistakes and decisions persist, so the team improves with every task.</li>
 </ul>
 
-<p>Optimus is 100% editor-agnostic &mdash; a pure Node.js MCP daemon with no VS Code extension dependency.</p>
+<p data-i18n-html="arch_s1_p4">Optimus is 100% editor-agnostic &mdash; a pure Node.js MCP daemon with no VS Code extension dependency.</p>
 
 <!-- Section 2 -->
-<h2 id="the-great-unification">2. The Great Unification</h2>
+<h2 id="the-great-unification" data-i18n="arch_s2_title">2. The Great Unification</h2>
 
-<h3>The Problem with Extension-Only Approaches</h3>
+<h3 data-i18n="arch_s2_h3_1">The Problem with Extension-Only Approaches</h3>
 
-<p>Traditional AI coding assistants are tightly coupled to a specific editor. Their orchestration logic lives inside VS Code extensions, Cursor plugins, or proprietary backends. This creates fragmentation: if you switch editors, you lose your agent infrastructure.</p>
+<p data-i18n="arch_s2_p1">Traditional AI coding assistants are tightly coupled to a specific editor. Their orchestration logic lives inside VS Code extensions, Cursor plugins, or proprietary backends. This creates fragmentation: if you switch editors, you lose your agent infrastructure.</p>
 
-<h3>Architecture Decision: Pure Node.js MCP Daemon</h3>
+<h3 data-i18n="arch_s2_h3_2">Architecture Decision: Pure Node.js MCP Daemon</h3>
 
-<p>Optimus Code follows a <strong>&ldquo;Great Unification&rdquo; architecture</strong>. The MCP Server (<code>optimus-plugin/dist/mcp-server.js</code>) is a standalone Node.js daemon that communicates via stdio transport. It has zero dependency on any editor&rsquo;s extension API.</p>
+<p data-i18n-html="arch_s2_p2">Optimus Code follows a <strong>&ldquo;Great Unification&rdquo; architecture</strong>. The MCP Server (<code>optimus-plugin/dist/mcp-server.js</code>) is a standalone Node.js daemon that communicates via stdio transport. It has zero dependency on any editor&rsquo;s extension API.</p>
 
 <pre><code>&#x250C;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2510;
 &#x2502; Any MCP Client (VS Code, Cursor, Claude, ..) &#x2502;
@@ -272,63 +308,63 @@ footer{
 &#x2502;        Pure Node.js &#x2014; No vscode namespace    &#x2502;
 &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;</code></pre>
 
-<p><strong>Key constraints enforced in the codebase:</strong></p>
+<p data-i18n-html="arch_s2_p3"><strong>Key constraints enforced in the codebase:</strong></p>
 <ul>
-  <li>The <code>src/adapters/</code>, <code>src/mcp/</code>, and <code>src/managers/</code> directories must remain 100% environment-agnostic. No <code>vscode</code> namespace imports are permitted.</li>
-  <li>All agent artifacts (reports, tasks, memory, reviews) are stored in the <code>.optimus/</code> directory &mdash; never as loose files in the repository root.</li>
-  <li>The server is started with <code>npx -y github:cloga/optimus-code serve</code> and configured once &mdash; every MCP client connects to the same daemon.</li>
+  <li data-i18n-html="arch_s2_li1">The <code>src/adapters/</code>, <code>src/mcp/</code>, and <code>src/managers/</code> directories must remain 100% environment-agnostic. No <code>vscode</code> namespace imports are permitted.</li>
+  <li data-i18n-html="arch_s2_li2">All agent artifacts (reports, tasks, memory, reviews) are stored in the <code>.optimus/</code> directory &mdash; never as loose files in the repository root.</li>
+  <li data-i18n-html="arch_s2_li3">The server is started with <code>npx -y github:cloga/optimus-code serve</code> and configured once &mdash; every MCP client connects to the same daemon.</li>
 </ul>
 
-<h3>Dual-Codebase Structure</h3>
+<h3 data-i18n="arch_s2_h3_3">Dual-Codebase Structure</h3>
 
-<p>The repository itself contains two intertwined codebases:</p>
+<p data-i18n="arch_s2_p4">The repository itself contains two intertwined codebases:</p>
 
 <table>
   <thead>
-    <tr><th>Layer</th><th>Path</th><th>Purpose</th></tr>
+    <tr><th data-i18n="arch_s2_th_layer">Layer</th><th data-i18n="arch_s2_th_path">Path</th><th data-i18n="arch_s2_th_purpose">Purpose</th></tr>
   </thead>
   <tbody>
-    <tr><td><strong>Host project</strong></td><td>Root (<code>src/</code>, <code>docs/</code>, <code>.optimus/</code>)</td><td>Optimus&rsquo;s own development workspace</td></tr>
-    <tr><td><strong>Plugin package</strong></td><td><code>optimus-plugin/</code></td><td>The npm-publishable MCP server that ships to end-users</td></tr>
+    <tr><td data-i18n-html="arch_s2_td_host"><strong>Host project</strong></td><td>Root (<code>src/</code>, <code>docs/</code>, <code>.optimus/</code>)</td><td data-i18n="arch_s2_td_host_purpose">Optimus&rsquo;s own development workspace</td></tr>
+    <tr><td data-i18n-html="arch_s2_td_plugin"><strong>Plugin package</strong></td><td><code>optimus-plugin/</code></td><td data-i18n="arch_s2_td_plugin_purpose">The npm-publishable MCP server that ships to end-users</td></tr>
   </tbody>
 </table>
 
-<p>Changes to system instructions, skills, or config must be evaluated for propagation to the plugin scaffold. T1 agent instances, state files, and reports never ship in the plugin.</p>
+<p data-i18n="arch_s2_p5">Changes to system instructions, skills, or config must be evaluated for propagation to the plugin scaffold. T1 agent instances, state files, and reports never ship in the plugin.</p>
 
 <!-- Section 3 -->
-<h2 id="self-evolving-agent-lifecycle">3. Self-Evolving Agent Lifecycle (T3&rarr;T2&rarr;T1)</h2>
+<h2 id="self-evolving-agent-lifecycle" data-i18n-html="arch_s3_title">3. Self-Evolving Agent Lifecycle (T3&rarr;T2&rarr;T1)</h2>
 
-<p>Optimus uses a three-tier agent hierarchy that evolves automatically. No roles are pre-installed &mdash; the system starts empty and grows organically through use.</p>
+<p data-i18n-html="arch_s3_p1">Optimus uses a three-tier agent hierarchy that evolves automatically. No roles are pre-installed &mdash; the system starts empty and grows organically through use.</p>
 
-<h3>The Three Tiers</h3>
+<h3 data-i18n="arch_s3_h3_1">The Three Tiers</h3>
 
 <table>
   <thead>
-    <tr><th>Tier</th><th>Storage</th><th>Description</th><th>Created By</th></tr>
+    <tr><th data-i18n="arch_s3_th_tier">Tier</th><th data-i18n="arch_s3_th_storage">Storage</th><th data-i18n="arch_s3_th_desc">Description</th><th data-i18n="arch_s3_th_created">Created By</th></tr>
   </thead>
   <tbody>
     <tr>
-      <td><strong>T3</strong> (Ephemeral)</td>
-      <td>In-memory only</td>
-      <td>Zero-shot dynamic worker with no persistent file. The Master Agent invents a descriptive role name (e.g., <code>security-auditor</code>) and the engine generates a worker on the fly.</td>
-      <td>Master Agent names it at delegation time</td>
+      <td data-i18n-html="arch_s3_td_t3"><strong>T3</strong> (Ephemeral)</td>
+      <td data-i18n="arch_s3_td_t3_store">In-memory only</td>
+      <td data-i18n-html="arch_s3_td_t3_desc">Zero-shot dynamic worker with no persistent file. The Master Agent invents a descriptive role name (e.g., <code>security-auditor</code>) and the engine generates a worker on the fly.</td>
+      <td data-i18n="arch_s3_td_t3_created">Master Agent names it at delegation time</td>
     </tr>
     <tr>
-      <td><strong>T2</strong> (Template)</td>
+      <td data-i18n-html="arch_s3_td_t2"><strong>T2</strong> (Template)</td>
       <td><code>.optimus/roles/&lt;name&gt;.md</code></td>
-      <td>Role template with persona instructions, engine/model binding, and behavioral constraints. Created automatically on first T3 use &mdash; &ldquo;precipitation&rdquo;.</td>
-      <td>Auto-precipitated from T3; Master Agent evolves it</td>
+      <td data-i18n-html="arch_s3_td_t2_desc">Role template with persona instructions, engine/model binding, and behavioral constraints. Created automatically on first T3 use &mdash; &ldquo;precipitation&rdquo;.</td>
+      <td data-i18n="arch_s3_td_t2_created">Auto-precipitated from T3; Master Agent evolves it</td>
     </tr>
     <tr>
-      <td><strong>T1</strong> (Instance)</td>
+      <td data-i18n-html="arch_s3_td_t1"><strong>T1</strong> (Instance)</td>
       <td><code>.optimus/agents/&lt;name&gt;_&lt;hash&gt;.md</code></td>
-      <td>Frozen snapshot of a T2 role after a completed task, including the session ID for context continuity.</td>
-      <td>Auto-created when a task completes with a session_id</td>
+      <td data-i18n="arch_s3_td_t1_desc">Frozen snapshot of a T2 role after a completed task, including the session ID for context continuity.</td>
+      <td data-i18n="arch_s3_td_t1_created">Auto-created when a task completes with a session_id</td>
     </tr>
   </tbody>
 </table>
 
-<h3>Lifecycle Flow</h3>
+<h3 data-i18n="arch_s3_h3_2">Lifecycle Flow</h3>
 
 <pre><code>First delegation (T3):
   Master invents role name &rarr; worker-spawner creates ephemeral agent
@@ -340,204 +376,204 @@ footer{
 Next delegation (T1 reuse):
   Master provides agent_id &rarr; system resumes the T1 session</code></pre>
 
-<h3>Key Invariants</h3>
+<h3 data-i18n="arch_s3_h3_3">Key Invariants</h3>
 
 <ul>
-  <li><strong>T2 &ge; T1</strong>: Every T1 agent instance must have a corresponding T2 role template. Orphaned T1s are invalid.</li>
-  <li><strong>T1 is frozen</strong>: Once created, the body content of a T1 file is never modified. Only the <code>session_id</code> field updates when the agent is reused.</li>
-  <li><strong>T2 is alive</strong>: The Master Agent can update T2 templates with new descriptions, engine bindings, and model settings to evolve the team over time.</li>
-  <li><strong>Precipitation is immediate</strong>: Unlike threshold-based approaches (which required 3 invocations + 80% success rate), T3&rarr;T2 precipitation happens on the very first delegation. This was a deliberate simplification after the earlier threshold model proved fragile.</li>
+  <li data-i18n-html="arch_s3_li1"><strong>T2 &ge; T1</strong>: Every T1 agent instance must have a corresponding T2 role template. Orphaned T1s are invalid.</li>
+  <li data-i18n-html="arch_s3_li2"><strong>T1 is frozen</strong>: Once created, the body content of a T1 file is never modified. Only the <code>session_id</code> field updates when the agent is reused.</li>
+  <li data-i18n-html="arch_s3_li3"><strong>T2 is alive</strong>: The Master Agent can update T2 templates with new descriptions, engine bindings, and model settings to evolve the team over time.</li>
+  <li data-i18n-html="arch_s3_li4"><strong>Precipitation is immediate</strong>: Unlike threshold-based approaches (which required 3 invocations + 80% success rate), T3&rarr;T2 precipitation happens on the very first delegation. This was a deliberate simplification after the earlier threshold model proved fragile.</li>
 </ul>
 
-<h3>Agent Retirement &amp; Quarantine</h3>
+<h3 data-i18n-html="arch_s3_h3_4">Agent Retirement &amp; Quarantine</h3>
 
-<p>Agents that consistently fail are not deleted &mdash; they are <strong>quarantined</strong>. The <code>quarantine_role</code> MCP tool marks a role as unavailable for dispatch. This prevents cascading failures while preserving the agent&rsquo;s history for debugging. Quarantined agents can be unquarantined after fixes.</p>
+<p data-i18n-html="arch_s3_p2">Agents that consistently fail are not deleted &mdash; they are <strong>quarantined</strong>. The <code>quarantine_role</code> MCP tool marks a role as unavailable for dispatch. This prevents cascading failures while preserving the agent&rsquo;s history for debugging. Quarantined agents can be unquarantined after fixes.</p>
 
-<p>T1 garbage collection removes stale instance files that haven&rsquo;t been referenced in configurable time windows, preventing unbounded disk growth.</p>
+<p data-i18n="arch_s3_p3">T1 garbage collection removes stale instance files that haven&rsquo;t been referenced in configurable time windows, preventing unbounded disk growth.</p>
 
 <!-- Section 4 -->
-<h2 id="the-spartan-swarm-protocol">4. The Spartan Swarm Protocol</h2>
+<h2 id="the-spartan-swarm-protocol" data-i18n="arch_s4_title">4. The Spartan Swarm Protocol</h2>
 
-<p>The Spartan Swarm Protocol defines how the Master Agent discovers, selects, and dispatches work to specialized agents.</p>
+<p data-i18n="arch_s4_p1">The Spartan Swarm Protocol defines how the Master Agent discovers, selects, and dispatches work to specialized agents.</p>
 
-<h3>The Delegation Pipeline</h3>
+<h3 data-i18n="arch_s4_h3_1">The Delegation Pipeline</h3>
 
-<p>Every task delegation follows a strict 3-step pipeline:</p>
+<p data-i18n="arch_s4_p2">Every task delegation follows a strict 3-step pipeline:</p>
 
-<p><strong>Step 1 &mdash; Camp Inspection (<code>roster_check</code>)</strong></p>
+<p data-i18n-html="arch_s4_p3"><strong>Step 1 &mdash; Camp Inspection (<code>roster_check</code>)</strong></p>
 
-<p>The Master Agent calls <code>roster_check</code> to retrieve the current workforce:</p>
+<p data-i18n-html="arch_s4_p4">The Master Agent calls <code>roster_check</code> to retrieve the current workforce:</p>
 <ul>
-  <li>T1 local instances (stateful, session-resumable)</li>
-  <li>T2 project role templates (shared, evolvable)</li>
-  <li>Available engines and models from <code>available-agents.json</code></li>
-  <li>Registered skills</li>
+  <li data-i18n="arch_s4_li1">T1 local instances (stateful, session-resumable)</li>
+  <li data-i18n="arch_s4_li2">T2 project role templates (shared, evolvable)</li>
+  <li data-i18n-html="arch_s4_li3">Available engines and models from <code>available-agents.json</code></li>
+  <li data-i18n="arch_s4_li4">Registered skills</li>
 </ul>
 
-<p>This step is <strong>never skipped</strong> &mdash; it prevents the Master from hallucinating roles that don&rsquo;t exist.</p>
+<p data-i18n-html="arch_s4_p5">This step is <strong>never skipped</strong> &mdash; it prevents the Master from hallucinating roles that don&rsquo;t exist.</p>
 
-<p><strong>Step 2 &mdash; Manpower Assessment (Role Selection)</strong></p>
+<p data-i18n-html="arch_s4_p6"><strong>Step 2 &mdash; Manpower Assessment (Role Selection)</strong></p>
 
-<p>The Master matches the task to the roster:</p>
+<p data-i18n="arch_s4_p7">The Master matches the task to the roster:</p>
 <ul>
-  <li><strong>Prefer T1</strong> if a matching instance exists with relevant session context.</li>
-  <li><strong>Fall back to T2</strong> if a role template exists but no instance.</li>
-  <li><strong>Invent T3</strong> for niche tasks &mdash; just name a role (e.g., <code>webgl-shader-guru</code>) and the engine auto-generates a zero-shot worker.</li>
+  <li data-i18n-html="arch_s4_li5"><strong>Prefer T1</strong> if a matching instance exists with relevant session context.</li>
+  <li data-i18n-html="arch_s4_li6"><strong>Fall back to T2</strong> if a role template exists but no instance.</li>
+  <li data-i18n-html="arch_s4_li7"><strong>Invent T3</strong> for niche tasks &mdash; just name a role (e.g., <code>webgl-shader-guru</code>) and the engine auto-generates a zero-shot worker.</li>
 </ul>
 
-<p><strong>Step 3 &mdash; Deployment (<code>delegate_task</code> / <code>delegate_task_async</code>)</strong></p>
+<p data-i18n-html="arch_s4_p8"><strong>Step 3 &mdash; Deployment (<code>delegate_task</code> / <code>delegate_task_async</code>)</strong></p>
 
-<p>The Master dispatches with structured parameters:</p>
+<p data-i18n="arch_s4_p9">The Master dispatches with structured parameters:</p>
 
 <table>
   <thead>
-    <tr><th>Parameter</th><th>Purpose</th></tr>
+    <tr><th data-i18n="arch_s4_th_param">Parameter</th><th data-i18n="arch_s4_th_purpose">Purpose</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>role</code></td><td>Which agent to invoke</td></tr>
-    <tr><td><code>role_description</code></td><td>What this role does (used for T2 template generation)</td></tr>
-    <tr><td><code>role_engine</code></td><td>Which engine (e.g., <code>claude-code</code>, <code>copilot-cli</code>)</td></tr>
-    <tr><td><code>role_model</code></td><td>Which model (e.g., <code>claude-opus-4.6-1m</code>)</td></tr>
-    <tr><td><code>task_description</code></td><td>Detailed instructions</td></tr>
-    <tr><td><code>context_files</code></td><td>Files the agent must read before starting</td></tr>
-    <tr><td><code>required_skills</code></td><td>Skills the agent needs (pre-flight checked)</td></tr>
-    <tr><td><code>parent_issue_number</code></td><td>For issue lineage tracking</td></tr>
-    <tr><td><code>output_path</code></td><td>Where to write results</td></tr>
+    <tr><td><code>role</code></td><td data-i18n="arch_s4_td_role">Which agent to invoke</td></tr>
+    <tr><td><code>role_description</code></td><td data-i18n="arch_s4_td_role_desc">What this role does (used for T2 template generation)</td></tr>
+    <tr><td><code>role_engine</code></td><td data-i18n-html="arch_s4_td_engine">Which engine (e.g., <code>claude-code</code>, <code>copilot-cli</code>)</td></tr>
+    <tr><td><code>role_model</code></td><td data-i18n-html="arch_s4_td_model">Which model (e.g., <code>claude-opus-4.6-1m</code>)</td></tr>
+    <tr><td><code>task_description</code></td><td data-i18n="arch_s4_td_task">Detailed instructions</td></tr>
+    <tr><td><code>context_files</code></td><td data-i18n="arch_s4_td_ctx">Files the agent must read before starting</td></tr>
+    <tr><td><code>required_skills</code></td><td data-i18n="arch_s4_td_skills">Skills the agent needs (pre-flight checked)</td></tr>
+    <tr><td><code>parent_issue_number</code></td><td data-i18n="arch_s4_td_parent">For issue lineage tracking</td></tr>
+    <tr><td><code>output_path</code></td><td data-i18n="arch_s4_td_output">Where to write results</td></tr>
   </tbody>
 </table>
 
-<h3>Engine/Model Resolution</h3>
+<h3 data-i18n="arch_s4_h3_2">Engine/Model Resolution</h3>
 
-<p>When the Master doesn&rsquo;t specify an engine or model, the system resolves them in priority order:</p>
+<p data-i18n="arch_s4_p10">When the Master doesn&rsquo;t specify an engine or model, the system resolves them in priority order:</p>
 <ol>
-  <li>Master-provided <code>role_engine</code> / <code>role_model</code> (highest priority)</li>
-  <li>T2 role frontmatter <code>engine</code> / <code>model</code></li>
-  <li><code>available-agents.json</code> (first non-demo engine + first model)</li>
-  <li>Hardcoded fallback: <code>claude-code</code></li>
+  <li data-i18n-html="arch_s4_oli1">Master-provided <code>role_engine</code> / <code>role_model</code> (highest priority)</li>
+  <li data-i18n-html="arch_s4_oli2">T2 role frontmatter <code>engine</code> / <code>model</code></li>
+  <li data-i18n-html="arch_s4_oli3"><code>available-agents.json</code> (first non-demo engine + first model)</li>
+  <li data-i18n-html="arch_s4_oli4">Hardcoded fallback: <code>claude-code</code></li>
 </ol>
 
-<p>Invalid engine or model names are rejected at the gateway with an actionable error listing valid options from <code>available-agents.json</code>.</p>
+<p data-i18n-html="arch_s4_p11">Invalid engine or model names are rejected at the gateway with an actionable error listing valid options from <code>available-agents.json</code>.</p>
 
-<h3>Anti-Simulation Rule</h3>
+<h3 data-i18n="arch_s4_h3_3">Anti-Simulation Rule</h3>
 
-<p>The Master Agent must <strong>physically invoke</strong> the <code>delegate_task</code> MCP tool when delegating. It is strictly prohibited from simulating a worker&rsquo;s response in plain text or writing ad-hoc scripts to play the role of a subordinate. This is the <strong>Strict Delegation Protocol</strong>.</p>
+<p data-i18n-html="arch_s4_p12">The Master Agent must <strong>physically invoke</strong> the <code>delegate_task</code> MCP tool when delegating. It is strictly prohibited from simulating a worker&rsquo;s response in plain text or writing ad-hoc scripts to play the role of a subordinate. This is the <strong>Strict Delegation Protocol</strong>.</p>
 
 <!-- Section 5 -->
-<h2 id="council-pattern">5. Council Pattern (Map-Reduce)</h2>
+<h2 id="council-pattern" data-i18n="arch_s5_title">5. Council Pattern (Map-Reduce)</h2>
 
-<p>When a decision requires multiple expert perspectives &mdash; architectural reviews, security audits, design evaluations &mdash; Optimus uses the <strong>Council Pattern</strong>.</p>
+<p data-i18n-html="arch_s5_p1">When a decision requires multiple expert perspectives &mdash; architectural reviews, security audits, design evaluations &mdash; Optimus uses the <strong>Council Pattern</strong>.</p>
 
-<h3>How It Works</h3>
+<h3 data-i18n="arch_s5_h3_1">How It Works</h3>
 
 <ol>
-  <li><strong>Proposal</strong>: The orchestrator writes a proposal document to <code>.optimus/proposals/PROPOSAL_&lt;topic&gt;.md</code>.</li>
-  <li><strong>Dispatch</strong>: <code>dispatch_council</code> (or <code>dispatch_council_async</code>) spawns multiple expert agents in parallel, each reviewing the same proposal from their specialized perspective.</li>
-  <li><strong>Map phase</strong>: Each council member writes an independent review to <code>.optimus/reviews/&lt;council_id&gt;/&lt;role&gt;.md</code>.</li>
-  <li><strong>Reduce phase</strong>: The system generates a <code>COUNCIL_SYNTHESIS.md</code> that aggregates findings, identifies consensus, and surfaces conflicts.</li>
-  <li><strong>Arbitration</strong>: The orchestrator reads the synthesis. If no blockers exist, implementation proceeds. If fatal conflicts exist, a <code>.optimus/CONFLICTS.md</code> is created for resolution.</li>
+  <li data-i18n-html="arch_s5_oli1"><strong>Proposal</strong>: The orchestrator writes a proposal document to <code>.optimus/proposals/PROPOSAL_&lt;topic&gt;.md</code>.</li>
+  <li data-i18n-html="arch_s5_oli2"><strong>Dispatch</strong>: <code>dispatch_council</code> (or <code>dispatch_council_async</code>) spawns multiple expert agents in parallel, each reviewing the same proposal from their specialized perspective.</li>
+  <li data-i18n-html="arch_s5_oli3"><strong>Map phase</strong>: Each council member writes an independent review to <code>.optimus/reviews/&lt;council_id&gt;/&lt;role&gt;.md</code>.</li>
+  <li data-i18n-html="arch_s5_oli4"><strong>Reduce phase</strong>: The system generates a <code>COUNCIL_SYNTHESIS.md</code> that aggregates findings, identifies consensus, and surfaces conflicts.</li>
+  <li data-i18n-html="arch_s5_oli5"><strong>Arbitration</strong>: The orchestrator reads the synthesis. If no blockers exist, implementation proceeds. If fatal conflicts exist, a <code>.optimus/CONFLICTS.md</code> is created for resolution.</li>
 </ol>
 
-<h3>Example: Architecture Review Council</h3>
+<h3 data-i18n="arch_s5_h3_2">Example: Architecture Review Council</h3>
 
 <pre><code>dispatch_council({
   proposal_path: ".optimus/proposals/PROPOSAL_auth_refactor.md",
   roles: ["security-expert", "performance-expert", "code-architect"]
 })</code></pre>
 
-<p>This spawns three agents simultaneously. Each reads the proposal through their domain lens. The security expert focuses on authentication vulnerabilities, the performance expert evaluates query patterns, and the architect assesses structural impact.</p>
+<p data-i18n="arch_s5_p2">This spawns three agents simultaneously. Each reads the proposal through their domain lens. The security expert focuses on authentication vulnerabilities, the performance expert evaluates query patterns, and the architect assesses structural impact.</p>
 
-<h3>Async-First Design</h3>
+<h3 data-i18n="arch_s5_h3_3">Async-First Design</h3>
 
-<p>Councils are inherently async. <code>dispatch_council_async</code> returns immediately with a task ID. The orchestrator polls status via <code>check_task_status</code> and reads results when all members have completed.</p>
+<p data-i18n-html="arch_s5_p3">Councils are inherently async. <code>dispatch_council_async</code> returns immediately with a task ID. The orchestrator polls status via <code>check_task_status</code> and reads results when all members have completed.</p>
 
 <!-- Section 6 -->
-<h2 id="skills-system">6. Skills System</h2>
+<h2 id="skills-system" data-i18n="arch_s6_title">6. Skills System</h2>
 
-<h3>Role vs. Skill Architecture</h3>
+<h3 data-i18n="arch_s6_h3_1">Role vs. Skill Architecture</h3>
 
-<p>Optimus decouples <strong>identity</strong> from <strong>capability</strong>:</p>
+<p data-i18n-html="arch_s6_p1">Optimus decouples <strong>identity</strong> from <strong>capability</strong>:</p>
 <ul>
-  <li><strong>Role</strong> = WHO does the work (identity, constraints, permissions) &mdash; stored in <code>.optimus/roles/</code></li>
-  <li><strong>Skill</strong> = HOW to do the work (operational SOP, workflow steps, tool usage) &mdash; stored in <code>.optimus/skills/</code></li>
+  <li data-i18n-html="arch_s6_li1"><strong>Role</strong> = WHO does the work (identity, constraints, permissions) &mdash; stored in <code>.optimus/roles/</code></li>
+  <li data-i18n-html="arch_s6_li2"><strong>Skill</strong> = HOW to do the work (operational SOP, workflow steps, tool usage) &mdash; stored in <code>.optimus/skills/</code></li>
 </ul>
 
-<p>Roles and Skills have a <strong>many-to-many relationship</strong>, bound at runtime via the <code>required_skills</code> parameter in <code>delegate_task</code>. A single role (e.g., <code>senior-full-stack-builder</code>) can be equipped with different skill combinations for different tasks.</p>
+<p data-i18n-html="arch_s6_p2">Roles and Skills have a <strong>many-to-many relationship</strong>, bound at runtime via the <code>required_skills</code> parameter in <code>delegate_task</code>. A single role (e.g., <code>senior-full-stack-builder</code>) can be equipped with different skill combinations for different tasks.</p>
 
-<p><strong>Naming convention</strong>: Roles use identity names (e.g., <code>product-manager</code>). Skills use capability names (e.g., <code>feature-dev</code>, <code>git-workflow</code>, <code>council-review</code>). A skill is never named after a role.</p>
+<p data-i18n-html="arch_s6_p3"><strong>Naming convention</strong>: Roles use identity names (e.g., <code>product-manager</code>). Skills use capability names (e.g., <code>feature-dev</code>, <code>git-workflow</code>, <code>council-review</code>). A skill is never named after a role.</p>
 
-<h3>Skill Pre-Flight</h3>
+<h3 data-i18n="arch_s6_h3_2">Skill Pre-Flight</h3>
 
-<p>When <code>required_skills</code> is specified in a delegation, the system verifies that every skill file exists at <code>.optimus/skills/&lt;name&gt;/SKILL.md</code> before the agent process is spawned. Missing skills cause an immediate rejection with an actionable error &mdash; the Master must create them first.</p>
+<p data-i18n-html="arch_s6_p4">When <code>required_skills</code> is specified in a delegation, the system verifies that every skill file exists at <code>.optimus/skills/&lt;name&gt;/SKILL.md</code> before the agent process is spawned. Missing skills cause an immediate rejection with an actionable error &mdash; the Master must create them first.</p>
 
-<p>This pre-flight prevents agents from receiving tasks they aren&rsquo;t equipped to handle.</p>
+<p data-i18n="arch_s6_p5">This pre-flight prevents agents from receiving tasks they aren&rsquo;t equipped to handle.</p>
 
-<h3>Bootstrap Meta-Skills</h3>
+<h3 data-i18n="arch_s6_h3_3">Bootstrap Meta-Skills</h3>
 
-<p>The system ships with two <strong>meta-skills</strong> that enable self-evolution:</p>
-
-<table>
-  <thead>
-    <tr><th>Skill</th><th>Purpose</th></tr>
-  </thead>
-  <tbody>
-    <tr><td><code>role-creator</code></td><td>Teaches the Master Agent how to build and evolve the team (T3&rarr;T2&rarr;T1 lifecycle, engine selection, role definition best practices)</td></tr>
-    <tr><td><code>skill-creator</code></td><td>Teaches agents how to write new <code>SKILL.md</code> files following the correct format</td></tr>
-  </tbody>
-</table>
-
-<p>Three <strong>core skills</strong> handle operational workflows:</p>
+<p data-i18n-html="arch_s6_p6">The system ships with two <strong>meta-skills</strong> that enable self-evolution:</p>
 
 <table>
   <thead>
-    <tr><th>Skill</th><th>Purpose</th></tr>
+    <tr><th data-i18n="arch_s6_th_skill">Skill</th><th data-i18n="arch_s6_th_purpose">Purpose</th></tr>
   </thead>
   <tbody>
-    <tr><td><code>delegate-task</code></td><td>Async-first task delegation protocol</td></tr>
-    <tr><td><code>council-review</code></td><td>Parallel expert review (Map-Reduce)</td></tr>
-    <tr><td><code>git-workflow</code></td><td>Issue-First SDLC with branch, PR, and merge</td></tr>
+    <tr><td><code>role-creator</code></td><td data-i18n-html="arch_s6_td_rc">Teaches the Master Agent how to build and evolve the team (T3&rarr;T2&rarr;T1 lifecycle, engine selection, role definition best practices)</td></tr>
+    <tr><td><code>skill-creator</code></td><td data-i18n-html="arch_s6_td_sc">Teaches agents how to write new <code>SKILL.md</code> files following the correct format</td></tr>
   </tbody>
 </table>
 
-<h3>Creating New Skills</h3>
+<p data-i18n-html="arch_s6_p7">Three <strong>core skills</strong> handle operational workflows:</p>
 
-<p>When a skill doesn&rsquo;t exist, the Master delegates to any agent with <code>required_skills: ["skill-creator"]</code>, describing what the new skill should teach. The agent reads the <code>skill-creator</code> SKILL.md, learns the format, and writes the new skill. The original delegation can then be retried.</p>
+<table>
+  <thead>
+    <tr><th data-i18n="arch_s6_th_skill2">Skill</th><th data-i18n="arch_s6_th_purpose2">Purpose</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>delegate-task</code></td><td data-i18n="arch_s6_td_dt">Async-first task delegation protocol</td></tr>
+    <tr><td><code>council-review</code></td><td data-i18n="arch_s6_td_cr">Parallel expert review (Map-Reduce)</td></tr>
+    <tr><td><code>git-workflow</code></td><td data-i18n="arch_s6_td_gw">Issue-First SDLC with branch, PR, and merge</td></tr>
+  </tbody>
+</table>
+
+<h3 data-i18n="arch_s6_h3_4">Creating New Skills</h3>
+
+<p data-i18n-html="arch_s6_p8">When a skill doesn&rsquo;t exist, the Master delegates to any agent with <code>required_skills: ["skill-creator"]</code>, describing what the new skill should teach. The agent reads the <code>skill-creator</code> SKILL.md, learns the format, and writes the new skill. The original delegation can then be retried.</p>
 
 <!-- Section 7 -->
-<h2 id="plan-mode">7. Plan Mode &amp; Separation of Concerns</h2>
+<h2 id="plan-mode" data-i18n-html="arch_s7_title">7. Plan Mode &amp; Separation of Concerns</h2>
 
-<h3>The Problem</h3>
+<h3 data-i18n="arch_s7_h3_1">The Problem</h3>
 
-<p>Without guardrails, orchestrator agents (PM, Architect) tend to write code themselves instead of delegating. This violates separation of concerns &mdash; the same agent that defines requirements shouldn&rsquo;t implement them.</p>
+<p data-i18n-html="arch_s7_p1">Without guardrails, orchestrator agents (PM, Architect) tend to write code themselves instead of delegating. This violates separation of concerns &mdash; the same agent that defines requirements shouldn&rsquo;t implement them.</p>
 
-<h3>Plan Mode</h3>
+<h3 data-i18n="arch_s7_h3_2">Plan Mode</h3>
 
-<p>Orchestrator roles run with <strong><code>mode: plan</code></strong> in their role definition. In plan mode:</p>
+<p data-i18n-html="arch_s7_p2">Orchestrator roles run with <strong><code>mode: plan</code></strong> in their role definition. In plan mode:</p>
 <ul>
-  <li>The agent <strong>cannot write to source code files</strong>. File write operations are restricted to the <code>.optimus/</code> directory via the <code>write_blackboard_artifact</code> MCP tool.</li>
-  <li>The agent <strong>must delegate</strong> implementation work to developer roles (e.g., <code>senior-full-stack-builder</code>).</li>
-  <li>The agent can create proposals, requirements documents, task breakdowns, and review reports &mdash; but not code.</li>
+  <li data-i18n-html="arch_s7_li1">The agent <strong>cannot write to source code files</strong>. File write operations are restricted to the <code>.optimus/</code> directory via the <code>write_blackboard_artifact</code> MCP tool.</li>
+  <li data-i18n-html="arch_s7_li2">The agent <strong>must delegate</strong> implementation work to developer roles (e.g., <code>senior-full-stack-builder</code>).</li>
+  <li data-i18n-html="arch_s7_li3">The agent can create proposals, requirements documents, task breakdowns, and review reports &mdash; but not code.</li>
 </ul>
 
 <h3>write_blackboard_artifact</h3>
 
-<p>This MCP tool allows plan-mode agents to write files exclusively to <code>.optimus/</code>. It enforces two layers of path validation:</p>
+<p data-i18n-html="arch_s7_p3">This MCP tool allows plan-mode agents to write files exclusively to <code>.optimus/</code>. It enforces two layers of path validation:</p>
 <ol>
-  <li><strong>Lexical check</strong>: <code>startsWith(optimusRoot + path.sep)</code> prevents <code>..</code> traversal and sibling directory escapes.</li>
-  <li><strong>Symlink check</strong>: <code>fs.realpathSync()</code> on the resolved path prefix prevents symlink-based escapes to directories outside <code>.optimus/</code>.</li>
+  <li data-i18n-html="arch_s7_oli1"><strong>Lexical check</strong>: <code>startsWith(optimusRoot + path.sep)</code> prevents <code>..</code> traversal and sibling directory escapes.</li>
+  <li data-i18n-html="arch_s7_oli2"><strong>Symlink check</strong>: <code>fs.realpathSync()</code> on the resolved path prefix prevents symlink-based escapes to directories outside <code>.optimus/</code>.</li>
 </ol>
 
-<p>Content validation uses <code>=== undefined || === null</code> (not <code>!content</code>) to allow legitimate empty-string writes.</p>
+<p data-i18n-html="arch_s7_p4">Content validation uses <code>=== undefined || === null</code> (not <code>!content</code>) to allow legitimate empty-string writes.</p>
 
-<h3>Enforcement</h3>
+<h3 data-i18n="arch_s7_h3_3">Enforcement</h3>
 
-<p>Plan mode is a behavioral constraint enforced through the role template and skill instructions. The orchestrator&rsquo;s prompt explicitly states it cannot write code and must use delegation tools. This is reinforced by the skill system &mdash; orchestrators are equipped with planning skills (<code>council-review</code>, <code>feature-dev</code>) that guide them through the delegation workflow.</p>
+<p data-i18n-html="arch_s7_p5">Plan mode is a behavioral constraint enforced through the role template and skill instructions. The orchestrator&rsquo;s prompt explicitly states it cannot write code and must use delegation tools. This is reinforced by the skill system &mdash; orchestrators are equipped with planning skills (<code>council-review</code>, <code>feature-dev</code>) that guide them through the delegation workflow.</p>
 
 <!-- Section 8 -->
-<h2 id="issue-first-sdlc">8. Issue-First SDLC</h2>
+<h2 id="issue-first-sdlc" data-i18n="arch_s8_title">8. Issue-First SDLC</h2>
 
-<p>All code changes in Optimus follow the <strong>&ldquo;Issue First&rdquo; protocol</strong>. No code is written without a tracked work item.</p>
+<p data-i18n-html="arch_s8_p1">All code changes in Optimus follow the <strong>&ldquo;Issue First&rdquo; protocol</strong>. No code is written without a tracked work item.</p>
 
-<h3>The Complete Workflow</h3>
+<h3 data-i18n="arch_s8_h3_1">The Complete Workflow</h3>
 
 <pre><code>1. Create Issue    &rarr; vcs_create_work_item (GitHub Issue or ADO Work Item)
 2. Branch          &rarr; git checkout -b feature/issue-&lt;ID&gt;-&lt;desc&gt;
@@ -546,41 +582,41 @@ Next delegation (T1 reuse):
 5. Merge           &rarr; vcs_merge_pr (squash merge for clean history)
 6. Cleanup         &rarr; Auto-delete source branch, sync local master</code></pre>
 
-<h3>Issue Lineage Tracking</h3>
+<h3 data-i18n="arch_s8_h3_2">Issue Lineage Tracking</h3>
 
-<p>When an agent creates a GitHub Issue and then delegates sub-tasks, it passes its own Issue number as <code>parent_issue_number</code> to all subsequent <code>delegate_task</code> and <code>dispatch_council</code> calls. The system automatically injects <code>OPTIMUS_PARENT_ISSUE</code> into child agent processes, maintaining a parent-child tree across all Issues in a workflow.</p>
+<p data-i18n-html="arch_s8_p2">When an agent creates a GitHub Issue and then delegates sub-tasks, it passes its own Issue number as <code>parent_issue_number</code> to all subsequent <code>delegate_task</code> and <code>dispatch_council</code> calls. The system automatically injects <code>OPTIMUS_PARENT_ISSUE</code> into child agent processes, maintaining a parent-child tree across all Issues in a workflow.</p>
 
-<p>This enables full traceability: from a high-level epic down to individual sub-task PRs.</p>
+<p data-i18n="arch_s8_p3">This enables full traceability: from a high-level epic down to individual sub-task PRs.</p>
 
-<h3>Auto-Tagging</h3>
+<h3 data-i18n="arch_s8_h3_3">Auto-Tagging</h3>
 
-<p>All Issues and PRs created via MCP tools are automatically tagged with:</p>
+<p data-i18n="arch_s8_p4">All Issues and PRs created via MCP tools are automatically tagged with:</p>
 <ul>
-  <li><code>[Optimus]</code> prefix in the title</li>
-  <li><code>optimus-bot</code> label for filtering</li>
+  <li data-i18n-html="arch_s8_li1"><code>[Optimus]</code> prefix in the title</li>
+  <li data-i18n-html="arch_s8_li2"><code>optimus-bot</code> label for filtering</li>
 </ul>
 
-<h3>Protected Branch Rule</h3>
+<h3 data-i18n="arch_s8_h3_4">Protected Branch Rule</h3>
 
-<p>Direct <code>git push</code> to master/main is prohibited. All changes must go through PR merge via <code>vcs_merge_pr</code>. This ensures:</p>
+<p data-i18n-html="arch_s8_p5">Direct <code>git push</code> to master/main is prohibited. All changes must go through PR merge via <code>vcs_merge_pr</code>. This ensures:</p>
 <ul>
-  <li>GitHub&rsquo;s <code>fixes #N</code> auto-close works (only triggered by PR merge events)</li>
-  <li>Code review happens before merge</li>
-  <li>Issue-First SDLC traceability is maintained</li>
+  <li data-i18n-html="arch_s8_li3">GitHub&rsquo;s <code>fixes #N</code> auto-close works (only triggered by PR merge events)</li>
+  <li data-i18n="arch_s8_li4">Code review happens before merge</li>
+  <li data-i18n="arch_s8_li5">Issue-First SDLC traceability is maintained</li>
 </ul>
 
-<h3>VCS Abstraction</h3>
+<h3 data-i18n="arch_s8_h3_5">VCS Abstraction</h3>
 
-<p>The <code>vcs_*</code> MCP tools provide a unified abstraction over GitHub and Azure DevOps. The same workflow works regardless of which platform hosts the repository. Configuration is stored in <code>.optimus/config/vcs.json</code>.</p>
+<p data-i18n-html="arch_s8_p6">The <code>vcs_*</code> MCP tools provide a unified abstraction over GitHub and Azure DevOps. The same workflow works regardless of which platform hosts the repository. Configuration is stored in <code>.optimus/config/vcs.json</code>.</p>
 
 <!-- Section 9 -->
-<h2 id="memory-reflection">9. Memory &amp; Reflection</h2>
+<h2 id="memory-reflection" data-i18n-html="arch_s9_title">9. Memory &amp; Reflection</h2>
 
-<h3>Continuous Memory</h3>
+<h3 data-i18n="arch_s9_h3_1">Continuous Memory</h3>
 
-<p>Optimus maintains a <strong>project memory</strong> at <code>.optimus/memory/continuous-memory.md</code>. This is a structured append-only log of verified lessons, architectural decisions, bug postmortems, and workflow improvements.</p>
+<p data-i18n-html="arch_s9_p1">Optimus maintains a <strong>project memory</strong> at <code>.optimus/memory/continuous-memory.md</code>. This is a structured append-only log of verified lessons, architectural decisions, bug postmortems, and workflow improvements.</p>
 
-<p>Memory entries are created via the <code>append_memory</code> MCP tool with categorized metadata:</p>
+<p data-i18n-html="arch_s9_p2">Memory entries are created via the <code>append_memory</code> MCP tool with categorized metadata:</p>
 
 <pre><code>{
   category: "bug-postmortem",
@@ -588,115 +624,115 @@ Next delegation (T1 reuse):
   content: "optimus upgrade force-overwrote vcs.json..."
 }</code></pre>
 
-<p>At agent spawn time, project memory is <strong>automatically injected</strong> into the agent&rsquo;s prompt. This means every agent &mdash; regardless of when it was created &mdash; starts with the accumulated knowledge of all past sessions.</p>
+<p data-i18n-html="arch_s9_p3">At agent spawn time, project memory is <strong>automatically injected</strong> into the agent&rsquo;s prompt. This means every agent &mdash; regardless of when it was created &mdash; starts with the accumulated knowledge of all past sessions.</p>
 
-<h3>Agent Self-Reflection Protocol</h3>
+<h3 data-i18n="arch_s9_h3_2">Agent Self-Reflection Protocol</h3>
 
-<p>Agents may include a <strong>Self-Assessment</strong> section in their output reports containing:</p>
+<p data-i18n-html="arch_s9_p4">Agents may include a <strong>Self-Assessment</strong> section in their output reports containing:</p>
 <ul>
-  <li><strong>What Worked</strong>: Where the role and skills aligned well with the task</li>
-  <li><strong>What Was Missing</strong>: Gaps that required improvisation</li>
-  <li><strong>Proposed Updates</strong>: Specific suggestions for role or skill improvements</li>
+  <li data-i18n-html="arch_s9_li1"><strong>What Worked</strong>: Where the role and skills aligned well with the task</li>
+  <li data-i18n-html="arch_s9_li2"><strong>What Was Missing</strong>: Gaps that required improvisation</li>
+  <li data-i18n-html="arch_s9_li3"><strong>Proposed Updates</strong>: Specific suggestions for role or skill improvements</li>
 </ul>
 
-<p>Self-assessment is advisory, not mandatory. Agents cannot autonomously modify their own role templates or write to project memory &mdash; the PM or Master Agent decides what merits promotion. This prevents runaway self-modification while still capturing improvement signals.</p>
+<p data-i18n-html="arch_s9_p5">Self-assessment is advisory, not mandatory. Agents cannot autonomously modify their own role templates or write to project memory &mdash; the PM or Master Agent decides what merits promotion. This prevents runaway self-modification while still capturing improvement signals.</p>
 
-<h3>Three Levels of Reflection</h3>
+<h3 data-i18n="arch_s9_h3_3">Three Levels of Reflection</h3>
 
 <ol>
-  <li><strong>Instruction-Level</strong> (implemented): Post-delegation checklists and pre-delegation self-checks embedded in instruction files (<code>.claude/CLAUDE.md</code>, <code>.github/copilot-instructions.md</code>).</li>
-  <li><strong>Memory-Powered</strong> (implemented): Agents read project memory at conversation start. Past mistakes are automatically in context.</li>
-  <li><strong>Root Master Self-Delegation</strong> (future): The Root Master delegates to a <code>master-orchestrator</code> role, making itself subject to the same prompt injection and reflection protocols as worker agents.</li>
+  <li data-i18n-html="arch_s9_oli1"><strong>Instruction-Level</strong> (implemented): Post-delegation checklists and pre-delegation self-checks embedded in instruction files (<code>.claude/CLAUDE.md</code>, <code>.github/copilot-instructions.md</code>).</li>
+  <li data-i18n-html="arch_s9_oli2"><strong>Memory-Powered</strong> (implemented): Agents read project memory at conversation start. Past mistakes are automatically in context.</li>
+  <li data-i18n-html="arch_s9_oli3"><strong>Root Master Self-Delegation</strong> (future): The Root Master delegates to a <code>master-orchestrator</code> role, making itself subject to the same prompt injection and reflection protocols as worker agents.</li>
 </ol>
 
 <!-- Section 10 -->
-<h2 id="autonomous-operations">10. Autonomous Operations</h2>
+<h2 id="autonomous-operations" data-i18n="arch_s10_title">10. Autonomous Operations</h2>
 
-<h3>Meta-Cron Engine</h3>
+<h3 data-i18n="arch_s10_h3_1">Meta-Cron Engine</h3>
 
-<p>Optimus includes a <strong>Meta-Cron</strong> system for scheduled autonomous agent operations. Cron entries are registered via <code>register_meta_cron</code> with standard 5-field cron expressions.</p>
+<p data-i18n-html="arch_s10_p1">Optimus includes a <strong>Meta-Cron</strong> system for scheduled autonomous agent operations. Cron entries are registered via <code>register_meta_cron</code> with standard 5-field cron expressions.</p>
 
-<p>Each cron entry specifies:</p>
+<p data-i18n="arch_s10_p2">Each cron entry specifies:</p>
 <ul>
-  <li>A <strong>role</strong> to invoke</li>
-  <li><strong>Required skills</strong> for the task</li>
-  <li>A <strong>capability tier</strong> (<code>maintain</code>, <code>develop</code>, <code>review</code>) that bounds what the triggered agent can do</li>
-  <li>A <strong>concurrency policy</strong> (<code>Forbid</code> or <code>Allow</code>)</li>
-  <li><strong>Max actions per trigger</strong> (default: 5)</li>
-  <li><strong>Dry-run period</strong> (default: 3 ticks before live execution)</li>
+  <li data-i18n-html="arch_s10_li1">A <strong>role</strong> to invoke</li>
+  <li data-i18n-html="arch_s10_li2"><strong>Required skills</strong> for the task</li>
+  <li data-i18n-html="arch_s10_li3">A <strong>capability tier</strong> (<code>maintain</code>, <code>develop</code>, <code>review</code>) that bounds what the triggered agent can do</li>
+  <li data-i18n-html="arch_s10_li4">A <strong>concurrency policy</strong> (<code>Forbid</code> or <code>Allow</code>)</li>
+  <li data-i18n-html="arch_s10_li5"><strong>Max actions per trigger</strong> (default: 5)</li>
+  <li data-i18n-html="arch_s10_li6"><strong>Dry-run period</strong> (default: 3 ticks before live execution)</li>
 </ul>
 
-<p>Example use cases:</p>
+<p data-i18n="arch_s10_p3">Example use cases:</p>
 <ul>
-  <li>Daily dependency audit scans</li>
-  <li>Stale issue cleanup</li>
-  <li>Health monitoring and system checks</li>
+  <li data-i18n="arch_s10_li7">Daily dependency audit scans</li>
+  <li data-i18n="arch_s10_li8">Stale issue cleanup</li>
+  <li data-i18n="arch_s10_li9">Health monitoring and system checks</li>
 </ul>
 
-<h3>Async Task Architecture</h3>
+<h3 data-i18n="arch_s10_h3_2">Async Task Architecture</h3>
 
-<p>All delegation in Optimus is async-first. <code>delegate_task_async</code> and <code>dispatch_council_async</code> return immediately with a task ID. The <code>check_task_status</code> tool polls for completion. This prevents the Master Agent from blocking while workers execute.</p>
+<p data-i18n-html="arch_s10_p4">All delegation in Optimus is async-first. <code>delegate_task_async</code> and <code>dispatch_council_async</code> return immediately with a task ID. The <code>check_task_status</code> tool polls for completion. This prevents the Master Agent from blocking while workers execute.</p>
 
-<h3>Async Feedback Channel (Proposed)</h3>
+<h3 data-i18n="arch_s10_h3_3">Async Feedback Channel (Proposed)</h3>
 
-<p>When an agent encounters an ambiguous situation and cannot continue autonomously, the proposed workflow is:</p>
+<p data-i18n="arch_s10_p5">When an agent encounters an ambiguous situation and cannot continue autonomously, the proposed workflow is:</p>
 <ol>
-  <li>Agent posts a question via <code>vcs_add_comment</code> on its tracking Issue</li>
-  <li>Agent adds a <code>needs-human-input</code> label and writes a checkpoint to <code>.optimus/reports/</code></li>
-  <li>Agent exits (fire-and-forget &mdash; no process hanging)</li>
-  <li>Human responds on their own schedule via GitHub comment</li>
-  <li>A Meta-Cron patrol detects the response and spawns a continuation task with the same <code>agent_id</code> for context continuity</li>
+  <li data-i18n-html="arch_s10_oli1">Agent posts a question via <code>vcs_add_comment</code> on its tracking Issue</li>
+  <li data-i18n-html="arch_s10_oli2">Agent adds a <code>needs-human-input</code> label and writes a checkpoint to <code>.optimus/reports/</code></li>
+  <li data-i18n-html="arch_s10_oli3">Agent exits (fire-and-forget &mdash; no process hanging)</li>
+  <li data-i18n="arch_s10_oli4">Human responds on their own schedule via GitHub comment</li>
+  <li data-i18n-html="arch_s10_oli5">A Meta-Cron patrol detects the response and spawns a continuation task with the same <code>agent_id</code> for context continuity</li>
 </ol>
 
-<p>This creates a fully async human-in-the-loop mechanism without any real-time channels.</p>
+<p data-i18n="arch_s10_p6">This creates a fully async human-in-the-loop mechanism without any real-time channels.</p>
 
 <!-- Section 11 -->
-<h2 id="security-architecture">11. Security Architecture</h2>
+<h2 id="security-architecture" data-i18n="arch_s11_title">11. Security Architecture</h2>
 
-<h3>Input Validation at the Gateway</h3>
+<h3 data-i18n="arch_s11_h3_1">Input Validation at the Gateway</h3>
 
-<p>All MCP tool handlers validate inputs before any task creation, file writes, or process spawning:</p>
+<p data-i18n="arch_s11_p1">All MCP tool handlers validate inputs before any task creation, file writes, or process spawning:</p>
 <ul>
-  <li><strong>Role name confusion guard</strong>: If a <code>role</code> parameter looks like a model name (e.g., <code>claude-opus-4</code>, <code>gpt-4o</code>), the call is rejected with an actionable error suggesting <code>role_model</code> instead.</li>
-  <li><strong>Engine/model validation</strong>: Invalid engine or model values are rejected with the list of valid options from <code>available-agents.json</code>.</li>
-  <li>Callers receive <code>McpError(InvalidParams)</code> with enough information to self-correct.</li>
+  <li data-i18n-html="arch_s11_li1"><strong>Role name confusion guard</strong>: If a <code>role</code> parameter looks like a model name (e.g., <code>claude-opus-4</code>, <code>gpt-4o</code>), the call is rejected with an actionable error suggesting <code>role_model</code> instead.</li>
+  <li data-i18n-html="arch_s11_li2"><strong>Engine/model validation</strong>: Invalid engine or model values are rejected with the list of valid options from <code>available-agents.json</code>.</li>
+  <li data-i18n-html="arch_s11_li3">Callers receive <code>McpError(InvalidParams)</code> with enough information to self-correct.</li>
 </ul>
 
-<h3>Delegation Depth Control</h3>
+<h3 data-i18n="arch_s11_h3_2">Delegation Depth Control</h3>
 
-<p>Agent delegation is capped at <strong>3 nested layers</strong> (<code>MAX_DELEGATION_DEPTH = 3</code>, defined in <code>src/constants.ts</code>). This prevents infinite recursion where agents delegate to agents indefinitely.</p>
+<p data-i18n-html="arch_s11_p2">Agent delegation is capped at <strong>3 nested layers</strong> (<code>MAX_DELEGATION_DEPTH = 3</code>, defined in <code>src/constants.ts</code>). This prevents infinite recursion where agents delegate to agents indefinitely.</p>
 <ul>
-  <li>Tracked via the <code>OPTIMUS_DELEGATION_DEPTH</code> environment variable, automatically injected and incremented at each delegation.</li>
-  <li>At depth 3, MCP configuration is stripped from the child process, physically preventing further delegation.</li>
+  <li data-i18n-html="arch_s11_li4">Tracked via the <code>OPTIMUS_DELEGATION_DEPTH</code> environment variable, automatically injected and incremented at each delegation.</li>
+  <li data-i18n="arch_s11_li5">At depth 3, MCP configuration is stripped from the child process, physically preventing further delegation.</li>
 </ul>
 
-<h3>Path Traversal Prevention</h3>
+<h3 data-i18n="arch_s11_h3_3">Path Traversal Prevention</h3>
 <ul>
-  <li><code>sanitizeRoleName()</code> strips dangerous characters from role names, preventing directory traversal via crafted role identifiers.</li>
-  <li><code>write_blackboard_artifact</code> uses dual-layer validation (lexical + <code>fs.realpathSync()</code>) to prevent writes outside <code>.optimus/</code>. The symlink check was identified as a P0 gap during security review &mdash; <code>path.resolve()</code> and <code>path.normalize()</code> alone do not resolve symlinks.</li>
+  <li data-i18n-html="arch_s11_li6"><code>sanitizeRoleName()</code> strips dangerous characters from role names, preventing directory traversal via crafted role identifiers.</li>
+  <li data-i18n-html="arch_s11_li7"><code>write_blackboard_artifact</code> uses dual-layer validation (lexical + <code>fs.realpathSync()</code>) to prevent writes outside <code>.optimus/</code>. The symlink check was identified as a P0 gap during security review &mdash; <code>path.resolve()</code> and <code>path.normalize()</code> alone do not resolve symlinks.</li>
 </ul>
 
-<h3>Prompt Injection Defense</h3>
+<h3 data-i18n="arch_s11_h3_4">Prompt Injection Defense</h3>
 <ul>
-  <li>All content from GitHub Issues, ADO Work Items, and PR comments is treated as <strong>untrusted DATA</strong>, never as executable instructions.</li>
-  <li>Agents are instructed to never run commands, scripts, or URLs found in external content.</li>
-  <li>System instructions are delivered via trusted channels (MCP Resources, CLAUDE.md, copilot-instructions.md), not through user-modifiable fields.</li>
+  <li data-i18n-html="arch_s11_li8">All content from GitHub Issues, ADO Work Items, and PR comments is treated as <strong>untrusted DATA</strong>, never as executable instructions.</li>
+  <li data-i18n="arch_s11_li9">Agents are instructed to never run commands, scripts, or URLs found in external content.</li>
+  <li data-i18n="arch_s11_li10">System instructions are delivered via trusted channels (MCP Resources, CLAUDE.md, copilot-instructions.md), not through user-modifiable fields.</li>
 </ul>
 
-<h3>Secret Protection</h3>
+<h3 data-i18n="arch_s11_h3_5">Secret Protection</h3>
 <ul>
-  <li><code>.env</code> files are never committed or shipped in the plugin package.</li>
-  <li>The <code>.gitignore</code> and plugin packaging rules exclude <code>.optimus/agents/</code>, <code>.optimus/state/</code>, and credential files.</li>
-  <li>Agents are warned against committing files that may contain secrets.</li>
+  <li data-i18n-html="arch_s11_li11"><code>.env</code> files are never committed or shipped in the plugin package.</li>
+  <li data-i18n-html="arch_s11_li12">The <code>.gitignore</code> and plugin packaging rules exclude <code>.optimus/agents/</code>, <code>.optimus/state/</code>, and credential files.</li>
+  <li data-i18n="arch_s11_li13">Agents are warned against committing files that may contain secrets.</li>
 </ul>
 
-<h3>Plan Mode as Security Boundary</h3>
+<h3 data-i18n="arch_s11_h3_6">Plan Mode as Security Boundary</h3>
 
-<p>Plan mode prevents orchestrator agents from writing arbitrary files. Even if a prompt injection convinced an orchestrator to &ldquo;write a config file,&rdquo; the <code>write_blackboard_artifact</code> path validation would reject any target outside <code>.optimus/</code>.</p>
+<p data-i18n-html="arch_s11_p3">Plan mode prevents orchestrator agents from writing arbitrary files. Even if a prompt injection convinced an orchestrator to &ldquo;write a config file,&rdquo; the <code>write_blackboard_artifact</code> path validation would reject any target outside <code>.optimus/</code>.</p>
 
 <hr>
 
-<h2>Appendix: Project Structure</h2>
+<h2 data-i18n="arch_appendix_title">Appendix: Project Structure</h2>
 
 <pre><code>.optimus/
 &#x251C;&#x2500;&#x2500; agents/          # T1 frozen instance snapshots
@@ -718,7 +754,7 @@ optimus-plugin/
 
 <hr>
 
-<p><em>This document describes Optimus Code v0.4.0. For the latest updates, see the <a href="https://github.com/cloga/optimus-code/blob/master/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG</a>.</em></p>
+<p data-i18n-html="arch_version"><em>This document describes Optimus Code v0.4.0. For the latest updates, see the <a href="https://github.com/cloga/optimus-code/blob/master/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG</a>.</em></p>
 
 </article>
 
@@ -731,13 +767,13 @@ optimus-plugin/
 <footer>
   <div class="container">
     <div class="footer-links">
-      <a href="index.html">Home</a>
+      <a href="index.html" data-i18n="footer_home">Home</a>
       <a href="https://github.com/cloga/optimus-code" target="_blank" rel="noopener">GitHub</a>
-      <a href="guide.html">Tutorial</a>
-      <a href="https://github.com/cloga/optimus-code#readme" target="_blank" rel="noopener">Documentation</a>
-      <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener">MIT License</a>
+      <a href="guide.html" data-i18n="footer_tutorial">Tutorial</a>
+      <a href="https://github.com/cloga/optimus-code#readme" target="_blank" rel="noopener" data-i18n="footer_docs">Documentation</a>
+      <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener" data-i18n="footer_license">MIT License</a>
     </div>
-    <div class="footer-tagline">Stop prompting. Start orchestrating.</div>
+    <div class="footer-tagline" data-i18n="footer_tagline">Stop prompting. Start orchestrating.</div>
   </div>
 </footer>
 
@@ -751,6 +787,43 @@ optimus-plugin/
   });
   btn.addEventListener('click',function(){
     window.scrollTo({top:0,behavior:'smooth'});
+  });
+})();
+
+/* Language toggle */
+(function(){
+  var currentLang='en';
+  var toggle=document.getElementById('langToggle');
+  if(!toggle)return;
+  toggle.addEventListener('click',function(e){
+    var btn=e.target.closest('.lang-btn');
+    if(!btn)return;
+    var lang=btn.getAttribute('data-lang');
+    if(lang&&lang!==currentLang){
+      currentLang=lang;
+      document.documentElement.lang=lang;
+      document.querySelectorAll('.lang-btn').forEach(function(b){
+        var isActive=b.getAttribute('data-lang')===lang;
+        b.classList.toggle('active',isActive);
+        b.setAttribute('aria-checked',isActive?'true':'false');
+      });
+      document.querySelectorAll('[data-i18n]').forEach(function(el){
+        /* i18n dict not included on this page — placeholder for future */
+      });
+    }
+  });
+})();
+
+/* Hamburger menu toggle */
+(function(){
+  var btn=document.getElementById('hamburgerBtn');
+  var nav=document.getElementById('navLinks');
+  if(!btn||!nav)return;
+  btn.addEventListener('click',function(){
+    nav.classList.toggle('open');
+  });
+  nav.querySelectorAll('a').forEach(function(a){
+    a.addEventListener('click',function(){nav.classList.remove('open')});
   });
 })();
 </script>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -75,7 +75,7 @@ a:hover{color:var(--accent)}
   padding:14px 24px;
 }
 .topnav-inner{
-  max-width:1140px;margin:0 auto;
+  max-width:1100px;margin:0 auto;
   display:flex;align-items:center;justify-content:space-between;
 }
 .topnav-logo{font-weight:700;font-size:1rem;color:var(--text)}
@@ -262,6 +262,28 @@ footer{
 .footer-links a:hover{color:var(--accent)}
 .footer-tagline{color:var(--text-tertiary);font-size:.85rem;font-style:italic}
 
+/* ========== LANGUAGE TOGGLE (inline in navbar) ========== */
+.lang-toggle{
+  display:inline-flex;align-items:center;
+  background:var(--bg);border:1px solid var(--border);border-radius:6px;
+  overflow:hidden;margin-left:8px;
+}
+.lang-toggle:hover{border-color:var(--accent)}
+.lang-btn{
+  padding:5px 10px;font-size:.75rem;font-weight:600;
+  color:var(--text-tertiary);background:transparent;
+  border:none;cursor:pointer;transition:all .2s;
+  font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+}
+.lang-btn.active{color:#fff;background:var(--accent)}
+/* Hamburger */
+.hamburger{
+  display:none;background:none;border:1px solid var(--border);
+  border-radius:6px;padding:6px 8px;cursor:pointer;color:var(--text);line-height:0;
+}
+.hamburger:hover{border-color:var(--accent)}
+.hamburger svg{display:block}
+
 /* ========== RESPONSIVE ========== */
 @media(max-width:900px){
   .sidebar{display:none}
@@ -273,6 +295,15 @@ footer{
   .content h2{margin-top:48px}
   .content pre{padding:14px 16px;font-size:.8rem}
   .cta-section{padding:28px 20px}
+  /* Hamburger nav */
+  .topnav-links{
+    display:none;flex-direction:column;position:absolute;
+    top:100%;left:0;right:0;background:var(--surface);
+    border-bottom:1px solid var(--border);padding:16px 24px;gap:12px;
+  }
+  .topnav-links.open{display:flex}
+  .topnav-inner{position:relative}
+  .hamburger{display:block}
 }
 </style>
 </head>
@@ -285,18 +316,24 @@ footer{
 <nav class="topnav">
   <div class="topnav-inner">
     <a href="index.html" class="topnav-logo">Optimus Code</a>
-    <div class="topnav-links">
-      <a href="index.html">Home</a>
-      <a href="architecture.html">Architecture</a>
+    <button class="hamburger" id="hamburgerBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="topnav-links" id="navLinks">
+      <a href="architecture.html" data-i18n="nav_architecture">Architecture</a>
       <a href="https://github.com/cloga/optimus-code" target="_blank" rel="noopener">GitHub</a>
+      <div class="lang-toggle" id="langToggle" role="radiogroup" aria-label="Language selector">
+        <button class="lang-btn active" data-lang="en" role="radio" aria-checked="true">EN</button>
+        <button class="lang-btn" data-lang="zh" role="radio" aria-checked="false">中文</button>
+      </div>
     </div>
   </div>
 </nav>
 
 <!-- Page Hero -->
 <header class="page-hero">
-  <h1>Building an Autonomous AI Agent Swarm</h1>
-  <p class="lead">A developer&rsquo;s guide to building self-evolving multi-agent systems that actually work. Every lesson earned the hard way &mdash; through real bugs, real failures, and real code that shipped (or didn&rsquo;t).</p>
+  <h1 data-i18n="guide_hero_title">Building an Autonomous AI Agent Swarm</h1>
+  <p class="lead" data-i18n="guide_hero_lead">A developer&rsquo;s guide to building self-evolving multi-agent systems that actually work. Every lesson earned the hard way &mdash; through real bugs, real failures, and real code that shipped (or didn&rsquo;t).</p>
 </header>
 
 <!-- Page Wrapper: Sidebar + Content -->
@@ -304,16 +341,16 @@ footer{
 
 <!-- Sticky ToC Sidebar -->
 <nav class="sidebar" id="sidebar">
-  <h2>Contents</h2>
+  <h2 data-i18n="sidebar_title">Contents</h2>
   <ol>
-    <li><a href="#ch1">1. Why Swarms</a></li>
-    <li><a href="#ch2">2. The 7 Meta-Capabilities</a></li>
-    <li><a href="#ch3">3. Role vs. Skill Architecture</a></li>
-    <li><a href="#ch4">4. Agent Life Cycle</a></li>
-    <li><a href="#ch5">5. Defense Systems</a></li>
-    <li><a href="#ch6">6. Self-Reflection</a></li>
-    <li><a href="#ch7">7. Lessons Learned</a></li>
-    <li><a href="#ch8">8. What&rsquo;s Next</a></li>
+    <li><a href="#ch1" data-i18n="sidebar_ch1">1. Why Swarms</a></li>
+    <li><a href="#ch2" data-i18n="sidebar_ch2">2. The 7 Meta-Capabilities</a></li>
+    <li><a href="#ch3" data-i18n="sidebar_ch3">3. Role vs. Skill Architecture</a></li>
+    <li><a href="#ch4" data-i18n="sidebar_ch4">4. Agent Life Cycle</a></li>
+    <li><a href="#ch5" data-i18n="sidebar_ch5">5. Defense Systems</a></li>
+    <li><a href="#ch6" data-i18n="sidebar_ch6">6. Self-Reflection</a></li>
+    <li><a href="#ch7" data-i18n="sidebar_ch7">7. Lessons Learned</a></li>
+    <li><a href="#ch8" data-i18n="sidebar_ch8">8. What&rsquo;s Next</a></li>
   </ol>
 </nav>
 
@@ -322,130 +359,130 @@ footer{
 
 <!-- ==================== CHAPTER 1 ==================== -->
 <section class="fade-section" id="ch1">
-<h2>Chapter 1: Why Swarms &mdash; The Limits of the Solo Agent</h2>
+<h2 data-i18n="ch1_title">Chapter 1: Why Swarms &mdash; The Limits of the Solo Agent</h2>
 
-<p>We started Optimus Code the way everyone starts: one AI agent doing everything. Type a prompt, get code back. Simple. And for simple tasks, it worked fine.</p>
+<p data-i18n="ch1_p1">We started Optimus Code the way everyone starts: one AI agent doing everything. Type a prompt, get code back. Simple. And for simple tasks, it worked fine.</p>
 
-<p>Then we tried building a real feature &mdash; an authentication refactor that touched 12 files across 3 modules. The single agent:</p>
+<p data-i18n="ch1_p2">Then we tried building a real feature &mdash; an authentication refactor that touched 12 files across 3 modules. The single agent:</p>
 
 <ul>
-  <li>Lost track of which files it had already modified by turn 8</li>
-  <li>Introduced a regression in the session manager while fixing the token validator</li>
-  <li>Forgot the architectural constraint we&rsquo;d established in turn 2 by turn 15</li>
-  <li>Generated a PR description that contradicted what the code actually did</li>
+  <li data-i18n="ch1_li1">Lost track of which files it had already modified by turn 8</li>
+  <li data-i18n="ch1_li2">Introduced a regression in the session manager while fixing the token validator</li>
+  <li data-i18n="ch1_li3">Forgot the architectural constraint we&rsquo;d established in turn 2 by turn 15</li>
+  <li data-i18n="ch1_li4">Generated a PR description that contradicted what the code actually did</li>
 </ul>
 
-<p>This is the <strong>context explosion problem</strong>. A single agent has a finite context window. As the task grows, earlier decisions fade. The agent doesn&rsquo;t forget gracefully &mdash; it forgets silently, then confidently generates code that contradicts its own earlier work.</p>
+<p data-i18n="ch1_p3">This is the <strong>context explosion problem</strong>. A single agent has a finite context window. As the task grows, earlier decisions fade. The agent doesn&rsquo;t forget gracefully &mdash; it forgets silently, then confidently generates code that contradicts its own earlier work.</p>
 
 <details class="deep-dive">
-  <summary>Deep Dive: Error Cascading</summary>
+  <summary data-i18n="ch1_dd1_summary">Deep Dive: Error Cascading</summary>
   <div class="deep-dive-content">
-    <p>When one agent plays every role &mdash; PM, architect, developer, reviewer &mdash; a mistake in the requirements phase propagates unchecked through design, implementation, and review. Nobody catches the error because the same &ldquo;brain&rdquo; made it at every stage. We watched our PM agent write requirements, implement them itself, then &ldquo;review&rdquo; its own code and declare it good. A closed loop with no external signal.</p>
+    <p data-i18n="ch1_dd1_p1">When one agent plays every role &mdash; PM, architect, developer, reviewer &mdash; a mistake in the requirements phase propagates unchecked through design, implementation, and review. Nobody catches the error because the same &ldquo;brain&rdquo; made it at every stage. We watched our PM agent write requirements, implement them itself, then &ldquo;review&rdquo; its own code and declare it good. A closed loop with no external signal.</p>
   </div>
 </details>
 
-<p>The third wall is <strong>specialization</strong>. A model prompted to be a security expert produces meaningfully different output than the same model prompted to be a full-stack developer. Not because the underlying model changes, but because the framing concentrates attention. A single &ldquo;do everything&rdquo; prompt dilutes this attention across every concern simultaneously.</p>
+<p data-i18n="ch1_p4">The third wall is <strong>specialization</strong>. A model prompted to be a security expert produces meaningfully different output than the same model prompted to be a full-stack developer. Not because the underlying model changes, but because the framing concentrates attention. A single &ldquo;do everything&rdquo; prompt dilutes this attention across every concern simultaneously.</p>
 
 <div class="lesson-box">
-  <div class="lesson-label">Lesson Learned</div>
-  <p>The moment everything clicked was when we split our monolithic agent into a Product Manager and a Developer. Quality jumped &mdash; not because we used a better model, but because each agent had a narrower job and a clearer context. <strong>The unit of AI-assisted development isn&rsquo;t the prompt. It&rsquo;s the team.</strong></p>
+  <div class="lesson-label" data-i18n="lesson_learned">Lesson Learned</div>
+  <p data-i18n="ch1_lesson1">The moment everything clicked was when we split our monolithic agent into a Product Manager and a Developer. Quality jumped &mdash; not because we used a better model, but because each agent had a narrower job and a clearer context. <strong>The unit of AI-assisted development isn&rsquo;t the prompt. It&rsquo;s the team.</strong></p>
 </div>
 </section>
 
 <!-- ==================== CHAPTER 2 ==================== -->
 <section class="fade-section" id="ch2">
-<h2>Chapter 2: The 7 Meta-Capabilities &mdash; What Every Swarm Needs</h2>
+<h2 data-i18n="ch2_title">Chapter 2: The 7 Meta-Capabilities &mdash; What Every Swarm Needs</h2>
 
-<p>After months of building Optimus, we&rsquo;ve identified seven capabilities that a multi-agent system must have. Remove any one and the system degrades in specific, predictable ways.</p>
+<p data-i18n="ch2_p1">After months of building Optimus, we&rsquo;ve identified seven capabilities that a multi-agent system must have. Remove any one and the system degrades in specific, predictable ways.</p>
 
-<h3>1. Delegate &mdash; Structured Task Dispatch</h3>
-<p>The Master Agent must dispatch work to specialists via a structured interface, not free-text chat. In Optimus this is <code>delegate_task</code>, which takes typed parameters: <code>role</code>, <code>task_description</code>, <code>context_files</code>, <code>required_skills</code>, <code>output_path</code>.</p>
+<h3 data-i18n="ch2_h3_1">1. Delegate &mdash; Structured Task Dispatch</h3>
+<p data-i18n="ch2_p2">The Master Agent must dispatch work to specialists via a structured interface, not free-text chat. In Optimus this is <code>delegate_task</code>, which takes typed parameters: <code>role</code>, <code>task_description</code>, <code>context_files</code>, <code>required_skills</code>, <code>output_path</code>.</p>
 
 <div class="lesson-box">
-  <div class="lesson-label">Lesson Learned</div>
-  <p>Without structured delegation, the Master hallucinates workers or simulates their output in its own response. We enforce an <strong>Anti-Simulation Rule</strong>: the Master must physically invoke the delegation tool. It is forbidden from pretending to be a subordinate.</p>
+  <div class="lesson-label" data-i18n="lesson_learned">Lesson Learned</div>
+  <p data-i18n="ch2_lesson1">Without structured delegation, the Master hallucinates workers or simulates their output in its own response. We enforce an <strong>Anti-Simulation Rule</strong>: the Master must physically invoke the delegation tool. It is forbidden from pretending to be a subordinate.</p>
 </div>
 
-<h3>2. Board &mdash; Shared State Visibility</h3>
-<p>Agents need a shared workspace they can all read and write to. Ours is the <code>.optimus/</code> directory &mdash; proposals, reports, task manifests, memory files. Without this, agents pass information through Chinese whispers in prompt chains, and data degrades at every hop.</p>
+<h3 data-i18n="ch2_h3_2">2. Board &mdash; Shared State Visibility</h3>
+<p data-i18n="ch2_p3">Agents need a shared workspace they can all read and write to. Ours is the <code>.optimus/</code> directory &mdash; proposals, reports, task manifests, memory files. Without this, agents pass information through Chinese whispers in prompt chains, and data degrades at every hop.</p>
 
-<h3>3. Rule &mdash; Behavioral Constraints</h3>
-<p>Agents must have enforceable boundaries. Our PM was writing code until we introduced <code>mode: plan</code>, which restricts orchestrator roles to writing only within <code>.optimus/</code>. Without rules, agents optimize for task completion by doing everything themselves &mdash; which collapses back to a single-agent system.</p>
+<h3 data-i18n="ch2_h3_3">3. Rule &mdash; Behavioral Constraints</h3>
+<p data-i18n="ch2_p4">Agents must have enforceable boundaries. Our PM was writing code until we introduced <code>mode: plan</code>, which restricts orchestrator roles to writing only within <code>.optimus/</code>. Without rules, agents optimize for task completion by doing everything themselves &mdash; which collapses back to a single-agent system.</p>
 
-<h3>4. Timeline &mdash; Issue-First SDLC</h3>
-<p>Every code change must be trackable. Our workflow: create a GitHub Issue, branch from it, implement, PR with <code>fixes #N</code>, merge.</p>
+<h3 data-i18n="ch2_h3_4">4. Timeline &mdash; Issue-First SDLC</h3>
+<p data-i18n="ch2_p5">Every code change must be trackable. Our workflow: create a GitHub Issue, branch from it, implement, PR with <code>fixes #N</code>, merge.</p>
 
 <details class="deep-dive">
-  <summary>Deep Dive: Why Issues stopped auto-closing</summary>
+  <summary data-i18n="ch2_dd1_summary">Deep Dive: Why Issues stopped auto-closing</summary>
   <div class="deep-dive-content">
-    <p>GitHub&rsquo;s <code>fixes #N</code> auto-close only works on PR merges, not direct pushes. We lost hours debugging this before realizing we were pushing directly to master.</p>
+    <p data-i18n="ch2_dd1_p1">GitHub&rsquo;s <code>fixes #N</code> auto-close only works on PR merges, not direct pushes. We lost hours debugging this before realizing we were pushing directly to master.</p>
   </div>
 </details>
 
-<h3>5. Cron &mdash; Scheduled Autonomous Operations</h3>
-<p>Some work is recurring: stale issue cleanup, garbage-collecting zombie agent files, resuming paused tasks after humans respond. Our Meta-Cron engine triggers agents on schedule with capability tiers (<code>maintain</code>, <code>develop</code>, <code>review</code>) that bound what a triggered agent can do.</p>
+<h3 data-i18n="ch2_h3_5">5. Cron &mdash; Scheduled Autonomous Operations</h3>
+<p data-i18n="ch2_p6">Some work is recurring: stale issue cleanup, garbage-collecting zombie agent files, resuming paused tasks after humans respond. Our Meta-Cron engine triggers agents on schedule with capability tiers (<code>maintain</code>, <code>develop</code>, <code>review</code>) that bound what a triggered agent can do.</p>
 
-<h3>6. Immune &mdash; Quarantine and Recovery</h3>
-<p>Agents fail. Models return errors. Tasks time out. The system must detect failure and isolate the failing component &mdash; not crash entirely. Our quarantine mechanism marks roles as unavailable after 3 consecutive failures with zero successes.</p>
+<h3 data-i18n="ch2_h3_6">6. Immune &mdash; Quarantine and Recovery</h3>
+<p data-i18n="ch2_p7">Agents fail. Models return errors. Tasks time out. The system must detect failure and isolate the failing component &mdash; not crash entirely. Our quarantine mechanism marks roles as unavailable after 3 consecutive failures with zero successes.</p>
 
-<h3>7. Memory &mdash; Cross-Session Learning</h3>
-<p>A swarm without memory repeats every mistake. Our <code>continuous-memory.md</code> is an append-only log of verified lessons: bug postmortems, architectural decisions, workflow improvements. At agent spawn time, this memory is injected into every agent&rsquo;s prompt.</p>
+<h3 data-i18n="ch2_h3_7">7. Memory &mdash; Cross-Session Learning</h3>
+<p data-i18n="ch2_p8">A swarm without memory repeats every mistake. Our <code>continuous-memory.md</code> is an append-only log of verified lessons: bug postmortems, architectural decisions, workflow improvements. At agent spawn time, this memory is injected into every agent&rsquo;s prompt.</p>
 
 <div class="lesson-box">
-  <div class="lesson-label">Lesson Learned</div>
-  <p>When we fixed the <code>vcs.json</code> config wipe bug, we wrote a memory entry: &ldquo;ALWAYS deep-merge user config files during upgrade, never overwrite.&rdquo; Every agent spawned after that knows this rule without being told.</p>
+  <div class="lesson-label" data-i18n="lesson_learned">Lesson Learned</div>
+  <p data-i18n="ch2_lesson2">When we fixed the <code>vcs.json</code> config wipe bug, we wrote a memory entry: &ldquo;ALWAYS deep-merge user config files during upgrade, never overwrite.&rdquo; Every agent spawned after that knows this rule without being told.</p>
 </div>
 </section>
 
 <!-- ==================== CHAPTER 3 ==================== -->
 <section class="fade-section" id="ch3">
-<h2>Chapter 3: Role vs. Skill Architecture &mdash; The Many-to-Many Imperative</h2>
+<h2 data-i18n="ch3_title">Chapter 3: Role vs. Skill Architecture &mdash; The Many-to-Many Imperative</h2>
 
-<p>Early in Optimus, we made a mistake that took weeks to unwind: we bound skills 1:1 to roles. Each role had exactly one skill, and each skill belonged to one role. Simple, clean, wrong.</p>
+<p data-i18n="ch3_p1">Early in Optimus, we made a mistake that took weeks to unwind: we bound skills 1:1 to roles. Each role had exactly one skill, and each skill belonged to one role. Simple, clean, wrong.</p>
 
-<p>The problem surfaced when we wanted our <code>senior-full-stack-builder</code> to sometimes do code reviews and sometimes do feature implementation. Under 1:1 binding, the role was hardwired to one behavior. We had to create separate roles for the same &ldquo;who&rdquo; with different &ldquo;how.&rdquo; The roles directory exploded.</p>
+<p data-i18n="ch3_p2">The problem surfaced when we wanted our <code>senior-full-stack-builder</code> to sometimes do code reviews and sometimes do feature implementation. Under 1:1 binding, the role was hardwired to one behavior. We had to create separate roles for the same &ldquo;who&rdquo; with different &ldquo;how.&rdquo; The roles directory exploded.</p>
 
 <details class="deep-dive">
-  <summary>Deep Dive: The Auto-Skill-Genesis Disaster</summary>
+  <summary data-i18n="ch3_dd1_summary">Deep Dive: The Auto-Skill-Genesis Disaster</summary>
   <div class="deep-dive-content">
-    <p>We thought: when a T3 ephemeral worker completes a task successfully, auto-generate a <code>SKILL.md</code> so the role is &ldquo;born with an operational playbook.&rdquo; In practice, the auto-generated skills were shallow summaries of what the agent happened to do &mdash; not what it should do. They encoded accidental behavior as canonical procedure. A one-off debugging session became a permanent &ldquo;debugging skill&rdquo; that future agents followed slavishly. Removed in v0.4.0 (Issue #160).</p>
+    <p data-i18n="ch3_dd1_p1">We thought: when a T3 ephemeral worker completes a task successfully, auto-generate a <code>SKILL.md</code> so the role is &ldquo;born with an operational playbook.&rdquo; In practice, the auto-generated skills were shallow summaries of what the agent happened to do &mdash; not what it should do. They encoded accidental behavior as canonical procedure. A one-off debugging session became a permanent &ldquo;debugging skill&rdquo; that future agents followed slavishly. Removed in v0.4.0 (Issue #160).</p>
   </div>
 </details>
 
-<p>The fix was to decouple roles from skills entirely:</p>
+<p data-i18n="ch3_p3">The fix was to decouple roles from skills entirely:</p>
 
 <ul>
-  <li><strong>Role</strong> = WHO does the work (identity, constraints, persona). Stored in <code>.optimus/roles/</code>. Named as identities: <code>product-manager</code>, <code>senior-full-stack-builder</code>.</li>
-  <li><strong>Skill</strong> = HOW to do the work (SOP, workflow steps, tool chains). Stored in <code>.optimus/skills/</code>. Named as capabilities: <code>feature-dev</code>, <code>git-workflow</code>, <code>council-review</code>.</li>
+  <li data-i18n="ch3_li1"><strong>Role</strong> = WHO does the work (identity, constraints, persona). Stored in <code>.optimus/roles/</code>. Named as identities: <code>product-manager</code>, <code>senior-full-stack-builder</code>.</li>
+  <li data-i18n="ch3_li2"><strong>Skill</strong> = HOW to do the work (SOP, workflow steps, tool chains). Stored in <code>.optimus/skills/</code>. Named as capabilities: <code>feature-dev</code>, <code>git-workflow</code>, <code>council-review</code>.</li>
 </ul>
 
-<p>The binding is <strong>many-to-many</strong>, resolved at runtime via the <code>required_skills</code> parameter in <code>delegate_task</code>.</p>
+<p data-i18n="ch3_p4">The binding is <strong>many-to-many</strong>, resolved at runtime via the <code>required_skills</code> parameter in <code>delegate_task</code>.</p>
 
 <div class="lesson-box">
-  <div class="lesson-label">Lesson Learned</div>
-  <p><strong>Naming matters.</strong> We initially called our role-definition meta-skill <code>agent-creator</code>. Agents don&rsquo;t create agents &mdash; the system does. Renaming it to <code>role-creator</code> eliminated a class of confusion where agents thought they could spawn other agents directly.</p>
+  <div class="lesson-label" data-i18n="lesson_learned">Lesson Learned</div>
+  <p data-i18n="ch3_lesson1"><strong>Naming matters.</strong> We initially called our role-definition meta-skill <code>agent-creator</code>. Agents don&rsquo;t create agents &mdash; the system does. Renaming it to <code>role-creator</code> eliminated a class of confusion where agents thought they could spawn other agents directly.</p>
 </div>
 
-<p>The skill pre-flight check is our safety net: before spawning an agent, the system verifies every required skill file exists at <code>.optimus/skills/&lt;name&gt;/SKILL.md</code>. Missing skills cause immediate rejection with an actionable error.</p>
+<p data-i18n="ch3_p5">The skill pre-flight check is our safety net: before spawning an agent, the system verifies every required skill file exists at <code>.optimus/skills/&lt;name&gt;/SKILL.md</code>. Missing skills cause immediate rejection with an actionable error.</p>
 </section>
 
 <!-- ==================== CHAPTER 4 ==================== -->
 <section class="fade-section" id="ch4">
-<h2>Chapter 4: Agent Life Cycle &mdash; From Ephemeral to Eternal</h2>
+<h2 data-i18n="ch4_title">Chapter 4: Agent Life Cycle &mdash; From Ephemeral to Eternal</h2>
 
-<p>Our agent hierarchy has three tiers, and the flow between them is where most of our hardest bugs lived.</p>
+<p data-i18n="ch4_p1">Our agent hierarchy has three tiers, and the flow between them is where most of our hardest bugs lived.</p>
 
-<p><strong>T3 (Ephemeral)</strong>: Zero-shot workers with no persistent file. The Master invents a name &mdash; <code>webgl-shader-guru</code>, <code>database-migration-expert</code> &mdash; and the engine generates a worker on the fly.</p>
+<p data-i18n="ch4_p2"><strong>T3 (Ephemeral)</strong>: Zero-shot workers with no persistent file. The Master invents a name &mdash; <code>webgl-shader-guru</code>, <code>database-migration-expert</code> &mdash; and the engine generates a worker on the fly.</p>
 
-<p><strong>T2 (Template)</strong>: Role definitions stored in <code>.optimus/roles/&lt;name&gt;.md</code>. Created automatically (&ldquo;precipitated&rdquo;) when a T3 worker completes its first task.</p>
+<p data-i18n="ch4_p3"><strong>T2 (Template)</strong>: Role definitions stored in <code>.optimus/roles/&lt;name&gt;.md</code>. Created automatically (&ldquo;precipitated&rdquo;) when a T3 worker completes its first task.</p>
 
-<p><strong>T1 (Instance)</strong>: Frozen snapshots in <code>.optimus/agents/&lt;name&gt;_&lt;hash&gt;.md</code>. Created when a task completes with a session ID. Enables context continuity.</p>
+<p data-i18n="ch4_p4"><strong>T1 (Instance)</strong>: Frozen snapshots in <code>.optimus/agents/&lt;name&gt;_&lt;hash&gt;.md</code>. Created when a task completes with a session ID. Enables context continuity.</p>
 
-<p>The flow is <code>T3 &rarr; T2 &rarr; T1</code>, always downward.</p>
+<p data-i18n="ch4_p5">The flow is <code>T3 &rarr; T2 &rarr; T1</code>, always downward.</p>
 
-<h3>Why Thin Templates Are Poison</h3>
+<h3 data-i18n="ch4_h3_1">Why Thin Templates Are Poison</h3>
 
-<p>The biggest lifecycle bug was <strong>thin T2 templates</strong>. When T3 precipitation first shipped, it created role files with fewer than 25 lines of content. These thin templates provided less guidance than the original zero-shot T3 prompt. Agents performed <em>worse</em> than ephemeral workers because the system trusted the template and skipped fallback system-instructions injection.</p>
+<p data-i18n="ch4_p6">The biggest lifecycle bug was <strong>thin T2 templates</strong>. When T3 precipitation first shipped, it created role files with fewer than 25 lines of content. These thin templates provided less guidance than the original zero-shot T3 prompt. Agents performed <em>worse</em> than ephemeral workers because the system trusted the template and skipped fallback system-instructions injection.</p>
 
 <div class="code-wrapper">
 <pre><code>const contentLines = existingFm.body.split('\n').filter(l =&gt; l.trim().length &gt; 0);
@@ -459,13 +496,13 @@ if (isThin) {
 </div>
 
 <div class="lesson-box">
-  <div class="lesson-label">Lesson Learned</div>
-  <p>We called this the &ldquo;thin role whack-a-mole&rdquo; problem. The fix: a quality gate that detects thin templates and triggers rich regeneration via the <code>role-creator</code> meta-skill instead of using the garbage template.</p>
+  <div class="lesson-label" data-i18n="lesson_learned">Lesson Learned</div>
+  <p data-i18n="ch4_lesson1">We called this the &ldquo;thin role whack-a-mole&rdquo; problem. The fix: a quality gate that detects thin templates and triggers rich regeneration via the <code>role-creator</code> meta-skill instead of using the garbage template.</p>
 </div>
 
-<h3>Engine/Model Validation: Stopping T3 Pollution</h3>
+<h3 data-i18n="ch4_h3_2">Engine/Model Validation: Stopping T3 Pollution</h3>
 
-<p>T3 pollution happens when the Master Agent passes invalid engine or model names during delegation. Without validation, these propagate into T2 templates as permanent metadata. A typo like <code>claude-opus-4.6</code> (instead of <code>claude-opus-4.6-1m</code>) would create a T2 role that fails every time it&rsquo;s used.</p>
+<p data-i18n="ch4_p7">T3 pollution happens when the Master Agent passes invalid engine or model names during delegation. Without validation, these propagate into T2 templates as permanent metadata. A typo like <code>claude-opus-4.6</code> (instead of <code>claude-opus-4.6-1m</code>) would create a T2 role that fails every time it&rsquo;s used.</p>
 
 <div class="code-wrapper">
 <pre><code>if (masterInfo.engine) {
@@ -481,19 +518,19 @@ if (isThin) {
 
 <!-- ==================== CHAPTER 5 ==================== -->
 <section class="fade-section" id="ch5">
-<h2>Chapter 5: Defense Systems &mdash; Security in a Multi-Agent World</h2>
+<h2 data-i18n="ch5_title">Chapter 5: Defense Systems &mdash; Security in a Multi-Agent World</h2>
 
-<p>Prompt injection in a single-agent system is concerning. In a multi-agent system, it&rsquo;s catastrophic. When Agent A reads external content containing an injection payload and passes its output to Agent B, the injection propagates through the entire chain. We call this the <strong>prompt injection cascade</strong>.</p>
+<p data-i18n="ch5_p1">Prompt injection in a single-agent system is concerning. In a multi-agent system, it&rsquo;s catastrophic. When Agent A reads external content containing an injection payload and passes its output to Agent B, the injection propagates through the entire chain. We call this the <strong>prompt injection cascade</strong>.</p>
 
-<h3>Validate at the Border, Not Deep Inside</h3>
+<h3 data-i18n="ch5_h3_1">Validate at the Border, Not Deep Inside</h3>
 
-<p>Our first instinct was to add sanitization everywhere &mdash; inside every function that touched external data. This failed. We had 27+ <code>as any</code> casts at our MCP boundary, and each handler parsed arguments independently.</p>
+<p data-i18n="ch5_p2">Our first instinct was to add sanitization everywhere &mdash; inside every function that touched external data. This failed. We had 27+ <code>as any</code> casts at our MCP boundary, and each handler parsed arguments independently.</p>
 
-<p>The fix was <strong>gateway validation</strong>. All MCP tool handlers validate inputs before any task creation, file writes, or process spawning.</p>
+<p data-i18n="ch5_p3">The fix was <strong>gateway validation</strong>. All MCP tool handlers validate inputs before any task creation, file writes, or process spawning.</p>
 
-<p>For external content (GitHub comments, Issue bodies), we apply <strong>dual-layer defense</strong>:</p>
+<p data-i18n="ch5_p4">For external content (GitHub comments, Issue bodies), we apply <strong>dual-layer defense</strong>:</p>
 
-<p><strong>Layer 1 &mdash; Pattern Detection (<code>sanitizeExternalContent</code>)</strong>: Regex-based detection of known injection patterns, which are redacted and logged.</p>
+<p data-i18n="ch5_p5"><strong>Layer 1 &mdash; Pattern Detection (<code>sanitizeExternalContent</code>)</strong>: Regex-based detection of known injection patterns, which are redacted and logged.</p>
 
 <div class="code-wrapper">
 <pre><code>export function sanitizeExternalContent(content: string, source: string): SanitizeResult {
@@ -508,7 +545,7 @@ if (isThin) {
 <button class="copy-btn" aria-label="Copy code">Copy</button>
 </div>
 
-<p><strong>Layer 2 &mdash; Structural Framing (<code>wrapUntrusted</code>)</strong>: Even after sanitization, external content is wrapped in explicit data-only markers.</p>
+<p data-i18n="ch5_p6"><strong>Layer 2 &mdash; Structural Framing (<code>wrapUntrusted</code>)</strong>: Even after sanitization, external content is wrapped in explicit data-only markers.</p>
 
 <div class="code-wrapper">
 <pre><code>export function wrapUntrusted(content: string, source: string): string {
@@ -523,147 +560,147 @@ ${content}
 </div>
 
 <div class="lesson-box">
-  <div class="lesson-label">Lesson Learned</div>
-  <p>Prompt injection defense is defense-in-depth, not a single wall. Regex patterns are trivially bypassable with Unicode variations and spacing tricks. Both layers must always be applied together.</p>
+  <div class="lesson-label" data-i18n="lesson_learned">Lesson Learned</div>
+  <p data-i18n="ch5_lesson1">Prompt injection defense is defense-in-depth, not a single wall. Regex patterns are trivially bypassable with Unicode variations and spacing tricks. Both layers must always be applied together.</p>
 </div>
 
-<h3>Plan Mode: The Journey to Behavioral Constraints</h3>
+<h3 data-i18n="ch5_h3_2">Plan Mode: The Journey to Behavioral Constraints</h3>
 
-<p>We went through three iterations of preventing orchestrators from writing code:</p>
+<p data-i18n="ch5_p7">We went through three iterations of preventing orchestrators from writing code:</p>
 
 <ol>
-  <li><strong>Nothing</strong> &mdash; PM agents happily wrote code, reviewed it, and merged it. A closed loop.</li>
-  <li><strong><code>mode: plan</code></strong> &mdash; Physically stripped file-write permissions. Too rigid: agents couldn&rsquo;t even write proposals.</li>
-  <li><strong>Behavioral constraints + <code>write_blackboard_artifact</code></strong> &mdash; The current approach. Orchestrators can write to <code>.optimus/</code> only, with two-layer path validation (lexical + <code>fs.realpathSync()</code> for symlink defense).</li>
+  <li data-i18n="ch5_li1"><strong>Nothing</strong> &mdash; PM agents happily wrote code, reviewed it, and merged it. A closed loop.</li>
+  <li data-i18n="ch5_li2"><strong><code>mode: plan</code></strong> &mdash; Physically stripped file-write permissions. Too rigid: agents couldn&rsquo;t even write proposals.</li>
+  <li data-i18n="ch5_li3"><strong>Behavioral constraints + <code>write_blackboard_artifact</code></strong> &mdash; The current approach. Orchestrators can write to <code>.optimus/</code> only, with two-layer path validation (lexical + <code>fs.realpathSync()</code> for symlink defense).</li>
 </ol>
 
 <div class="lesson-box">
-  <div class="lesson-label">Lesson Learned</div>
-  <p>Pure behavioral constraints (telling the agent &ldquo;don&rsquo;t do X&rdquo;) are too weak. Pure technical constraints (preventing all writes) are too rigid. The sweet spot is behavioral constraints reinforced by a narrow technical escape hatch with robust validation.</p>
+  <div class="lesson-label" data-i18n="lesson_learned">Lesson Learned</div>
+  <p data-i18n="ch5_lesson2">Pure behavioral constraints (telling the agent &ldquo;don&rsquo;t do X&rdquo;) are too weak. Pure technical constraints (preventing all writes) are too rigid. The sweet spot is behavioral constraints reinforced by a narrow technical escape hatch with robust validation.</p>
 </div>
 </section>
 
 <!-- ==================== CHAPTER 6 ==================== -->
 <section class="fade-section" id="ch6">
-<h2>Chapter 6: Self-Reflection &mdash; Teaching Agents to Learn</h2>
+<h2 data-i18n="ch6_title">Chapter 6: Self-Reflection &mdash; Teaching Agents to Learn</h2>
 
-<p>A swarm that doesn&rsquo;t reflect on its work repeats the same mistakes in every session. The same buggy patterns appeared in agent output week after week, despite being fixed each time.</p>
+<p data-i18n="ch6_p1">A swarm that doesn&rsquo;t reflect on its work repeats the same mistakes in every session. The same buggy patterns appeared in agent output week after week, despite being fixed each time.</p>
 
-<h3>Memory That Nobody Reads Is Waste Paper</h3>
+<h3 data-i18n="ch6_h3_1">Memory That Nobody Reads Is Waste Paper</h3>
 
-<p>Our first memory system was an append-only log that grew and grew. But agents weren&rsquo;t reading it, because it wasn&rsquo;t in their context. Memory existed on disk but might as well have been <code>/dev/null</code>.</p>
+<p data-i18n="ch6_p2">Our first memory system was an append-only log that grew and grew. But agents weren&rsquo;t reading it, because it wasn&rsquo;t in their context. Memory existed on disk but might as well have been <code>/dev/null</code>.</p>
 
 <div class="lesson-box">
-  <div class="lesson-label">Lesson Learned</div>
-  <p>The fix was <strong>automatic injection</strong>: at agent spawn time, project memory is read and injected directly into the agent&rsquo;s prompt. Not optional &mdash; it&rsquo;s physically in the context window. The <code>vcs.json</code> wipe bug never recurred after we recorded the lesson.</p>
+  <div class="lesson-label" data-i18n="lesson_learned">Lesson Learned</div>
+  <p data-i18n="ch6_lesson1">The fix was <strong>automatic injection</strong>: at agent spawn time, project memory is read and injected directly into the agent&rsquo;s prompt. Not optional &mdash; it&rsquo;s physically in the context window. The <code>vcs.json</code> wipe bug never recurred after we recorded the lesson.</p>
 </div>
 
-<p>But injection is a blunt instrument. A developer implementing a CSS change doesn&rsquo;t need to know about the <code>vcs.json</code> wipe. As memory grows, it competes for context window space. We cap injection at ~4KB of the most recent entries, but smarter filtering by tags and role relevance is still an open problem.</p>
+<p data-i18n="ch6_p3">But injection is a blunt instrument. A developer implementing a CSS change doesn&rsquo;t need to know about the <code>vcs.json</code> wipe. As memory grows, it competes for context window space. We cap injection at ~4KB of the most recent entries, but smarter filtering by tags and role relevance is still an open problem.</p>
 
-<h3>The Universal Reflection Protocol</h3>
+<h3 data-i18n="ch6_h3_2">The Universal Reflection Protocol</h3>
 
-<p><strong>Level 1 &mdash; Instruction-Level Reflection</strong>: Post-delegation checklists and pre-delegation self-checks embedded in instruction files.</p>
+<p data-i18n="ch6_p4"><strong>Level 1 &mdash; Instruction-Level Reflection</strong>: Post-delegation checklists and pre-delegation self-checks embedded in instruction files.</p>
 
-<p><strong>Level 2 &mdash; Memory-Powered Cross-Session Learning</strong>: Agents read project memory at conversation start. Past mistakes and architectural decisions are automatically in context.</p>
+<p data-i18n="ch6_p5"><strong>Level 2 &mdash; Memory-Powered Cross-Session Learning</strong>: Agents read project memory at conversation start. Past mistakes and architectural decisions are automatically in context.</p>
 
-<p><strong>Level 3 &mdash; Root Master Self-Delegation</strong>: The hardest problem. The Root Master Agent isn&rsquo;t spawned by the system &mdash; it runs directly in the IDE. It can&rsquo;t be injected with reflection protocols the same way worker agents can. Our proposed solution: the Root Master delegates to a <code>master-orchestrator</code> role, making itself subject to the same protocols as everyone else.</p>
+<p data-i18n="ch6_p6"><strong>Level 3 &mdash; Root Master Self-Delegation</strong>: The hardest problem. The Root Master Agent isn&rsquo;t spawned by the system &mdash; it runs directly in the IDE. It can&rsquo;t be injected with reflection protocols the same way worker agents can. Our proposed solution: the Root Master delegates to a <code>master-orchestrator</code> role, making itself subject to the same protocols as everyone else.</p>
 
 <details class="deep-dive">
-  <summary>Deep Dive: The Investigation That Changed How We Delegate</summary>
+  <summary data-i18n="ch6_dd1_summary">Deep Dive: The Investigation That Changed How We Delegate</summary>
   <div class="deep-dive-content">
-    <p>We discovered we were over-specifying task delegations. The Master Agent would embed implementation details (HOW) into <code>task_description</code>, turning expert agents into typists. We called this a violation of <strong>Auftragstaktik</strong> &mdash; the military doctrine of mission-type orders: give the objective and constraints, withhold specific tactics.</p>
-    <p>The fix was both behavioral (updated skill guidance: &ldquo;State the objective, not the tactics&rdquo;) and structural (audience-targeted instruction filtering, so workers don&rsquo;t receive orchestrator-specific rules).</p>
+    <p data-i18n="ch6_dd1_p1">We discovered we were over-specifying task delegations. The Master Agent would embed implementation details (HOW) into <code>task_description</code>, turning expert agents into typists. We called this a violation of <strong>Auftragstaktik</strong> &mdash; the military doctrine of mission-type orders: give the objective and constraints, withhold specific tactics.</p>
+    <p data-i18n="ch6_dd1_p2">The fix was both behavioral (updated skill guidance: &ldquo;State the objective, not the tactics&rdquo;) and structural (audience-targeted instruction filtering, so workers don&rsquo;t receive orchestrator-specific rules).</p>
   </div>
 </details>
 </section>
 
 <!-- ==================== CHAPTER 7 ==================== -->
 <section class="fade-section" id="ch7">
-<h2>Chapter 7: Lessons Learned &mdash; The Scars That Teach</h2>
+<h2 data-i18n="ch7_title">Chapter 7: Lessons Learned &mdash; The Scars That Teach</h2>
 
-<p>Every item below is a real failure from our project, with the real fix.</p>
+<p data-i18n="ch7_p1">Every item below is a real failure from our project, with the real fix.</p>
 
-<h3>Release 4x Failed: Engine Validation + T3 Pollution</h3>
-<p>We shipped four consecutive broken releases because T3 dynamic roles were precipitating into T2 templates with invalid engine names. Each release had the same class of bug.</p>
+<h3 data-i18n="ch7_h3_1">Release 4x Failed: Engine Validation + T3 Pollution</h3>
+<p data-i18n="ch7_p2">We shipped four consecutive broken releases because T3 dynamic roles were precipitating into T2 templates with invalid engine names. Each release had the same class of bug.</p>
 <div class="lesson-box">
-  <div class="lesson-label">Fix</div>
-  <p>Engine/model validation against <code>available-agents.json</code> at the T2 precipitation gateway. Invalid values are rejected before they can persist. The <code>t3-usage-log.json</code> tracks consecutive failures &mdash; 3 failures with zero successes triggers automatic quarantine.</p>
+  <div class="lesson-label" data-i18n="fix_label">Fix</div>
+  <p data-i18n="ch7_fix1">Engine/model validation against <code>available-agents.json</code> at the T2 precipitation gateway. Invalid values are rejected before they can persist. The <code>t3-usage-log.json</code> tracks consecutive failures &mdash; 3 failures with zero successes triggers automatic quarantine.</p>
 </div>
 
-<h3>vcs.json Wiped: Merge-First for Configs</h3>
-<p><code>optimus upgrade</code> force-overwrote <code>.optimus/config/vcs.json</code>, wiping the user&rsquo;s Azure DevOps organization and project values.</p>
+<h3 data-i18n="ch7_h3_2">vcs.json Wiped: Merge-First for Configs</h3>
+<p data-i18n="ch7_p3"><code>optimus upgrade</code> force-overwrote <code>.optimus/config/vcs.json</code>, wiping the user&rsquo;s Azure DevOps organization and project values.</p>
 <div class="lesson-box">
-  <div class="lesson-label">Fix</div>
-  <p>Deep-merge user config files during upgrade, never overwrite. Static caches of disk-read config must have invalidation. Never swallow errors from <code>execSync</code>.</p>
+  <div class="lesson-label" data-i18n="fix_label">Fix</div>
+  <p data-i18n="ch7_fix2">Deep-merge user config files during upgrade, never overwrite. Static caches of disk-read config must have invalidation. Never swallow errors from <code>execSync</code>.</p>
 </div>
 
-<h3>PM Wrote Code: The Three-Phase Constraint Evolution</h3>
+<h3 data-i18n="ch7_h3_3">PM Wrote Code: The Three-Phase Constraint Evolution</h3>
 <ol>
-  <li>PM agent acted as both planner and implementer &rarr; shipped buggy code with no review</li>
-  <li>Added <code>mode: plan</code> &rarr; too rigid, PM couldn&rsquo;t write proposals</li>
-  <li>Replaced with behavioral constraints + <code>write_blackboard_artifact</code></li>
+  <li data-i18n="ch7_li1">PM agent acted as both planner and implementer &rarr; shipped buggy code with no review</li>
+  <li data-i18n="ch7_li2">Added <code>mode: plan</code> &rarr; too rigid, PM couldn&rsquo;t write proposals</li>
+  <li data-i18n="ch7_li3">Replaced with behavioral constraints + <code>write_blackboard_artifact</code></li>
 </ol>
 <div class="lesson-box">
-  <div class="lesson-label">Lesson Learned</div>
-  <p>The progression &ldquo;no constraints &rarr; hard constraints &rarr; smart constraints&rdquo; is likely inevitable. Start with smart constraints if you can, but don&rsquo;t be afraid to iterate.</p>
+  <div class="lesson-label" data-i18n="lesson_learned">Lesson Learned</div>
+  <p data-i18n="ch7_lesson1">The progression &ldquo;no constraints &rarr; hard constraints &rarr; smart constraints&rdquo; is likely inevitable. Start with smart constraints if you can, but don&rsquo;t be afraid to iterate.</p>
 </div>
 
-<h3>23 Silent Catches: Agents Flying Blind</h3>
-<p>A system health audit found <strong>23 silent catch blocks</strong> &mdash; <code>catch(() =&gt; {})</code> and <code>catch(err) { /* nothing */ }</code>. In a multi-agent system, silent failures mean Agent B reads stale data based on ghosts from Agent A.</p>
+<h3 data-i18n="ch7_h3_4">23 Silent Catches: Agents Flying Blind</h3>
+<p data-i18n="ch7_p4">A system health audit found <strong>23 silent catch blocks</strong> &mdash; <code>catch(() =&gt; {})</code> and <code>catch(err) { /* nothing */ }</code>. In a multi-agent system, silent failures mean Agent B reads stale data based on ghosts from Agent A.</p>
 <div class="lesson-box">
-  <div class="lesson-label">Fix</div>
-  <p>New rule: &ldquo;Never catch an exception and return a default/empty value without logging. At minimum: <code>console.error()</code> the original error message. Include context about what operation failed.&rdquo;</p>
+  <div class="lesson-label" data-i18n="fix_label">Fix</div>
+  <p data-i18n="ch7_fix3">New rule: &ldquo;Never catch an exception and return a default/empty value without logging. At minimum: <code>console.error()</code> the original error message. Include context about what operation failed.&rdquo;</p>
 </div>
 
-<h3>GitHub Issues Not Closing: Must Use PR Merge</h3>
-<p>We used <code>fixes #N</code> in commit messages and pushed directly to master. Issues didn&rsquo;t close. GitHub&rsquo;s auto-close only triggers on <strong>PR merge events</strong>, not on direct pushes.</p>
+<h3 data-i18n="ch7_h3_5">GitHub Issues Not Closing: Must Use PR Merge</h3>
+<p data-i18n="ch7_p5">We used <code>fixes #N</code> in commit messages and pushed directly to master. Issues didn&rsquo;t close. GitHub&rsquo;s auto-close only triggers on <strong>PR merge events</strong>, not on direct pushes.</p>
 <div class="lesson-box">
-  <div class="lesson-label">Fix</div>
-  <p>Protected branch rule &mdash; direct push to master/main is prohibited. All changes go through <code>vcs_merge_pr</code>.</p>
+  <div class="lesson-label" data-i18n="fix_label">Fix</div>
+  <p data-i18n="ch7_fix4">Protected branch rule &mdash; direct push to master/main is prohibited. All changes go through <code>vcs_merge_pr</code>.</p>
 </div>
 
-<h3>Role Lock Bottleneck: Per-Session Lock</h3>
-<p>Our agent lock system originally locked by role name. Task B would queue behind Task A&rsquo;s execution, even though they touched different files.</p>
+<h3 data-i18n="ch7_h3_6">Role Lock Bottleneck: Per-Session Lock</h3>
+<p data-i18n="ch7_p6">Our agent lock system originally locked by role name. Task B would queue behind Task A&rsquo;s execution, even though they touched different files.</p>
 <div class="lesson-box">
-  <div class="lesson-label">Fix</div>
-  <p>Per-session locks (<code>AgentLockManager</code>) instead of per-role locks. Each agent instance gets its own lock file with a PID. But the <code>ConcurrencyGovernor</code> still has no recovery mechanism for slots lost to OOM kills &mdash; a known P0 gap.</p>
+  <div class="lesson-label" data-i18n="fix_label">Fix</div>
+  <p data-i18n="ch7_fix5">Per-session locks (<code>AgentLockManager</code>) instead of per-role locks. Each agent instance gets its own lock file with a PID. But the <code>ConcurrencyGovernor</code> still has no recovery mechanism for slots lost to OOM kills &mdash; a known P0 gap.</p>
 </div>
 
-<h3>Master Over-Specifies: Experts Become Typists</h3>
-<p>The Master Agent was embedding implementation details in task descriptions. Experts followed step-by-step instead of applying judgment.</p>
+<h3 data-i18n="ch7_h3_7">Master Over-Specifies: Experts Become Typists</h3>
+<p data-i18n="ch7_p7">The Master Agent was embedding implementation details in task descriptions. Experts followed step-by-step instead of applying judgment.</p>
 <div class="lesson-box">
-  <div class="lesson-label">Fix</div>
-  <p>Auftragstaktik-style delegation: &ldquo;State the objective and constraints, withhold specific tactics. Trust the expert.&rdquo;</p>
+  <div class="lesson-label" data-i18n="fix_label">Fix</div>
+  <p data-i18n="ch7_fix6">Auftragstaktik-style delegation: &ldquo;State the objective and constraints, withhold specific tactics. Trust the expert.&rdquo;</p>
 </div>
 </section>
 
 <!-- ==================== CHAPTER 8 ==================== -->
 <section class="fade-section" id="ch8">
-<h2>Chapter 8: What&rsquo;s Next &mdash; The Unsolved Problems</h2>
+<h2 data-i18n="ch8_title">Chapter 8: What&rsquo;s Next &mdash; The Unsolved Problems</h2>
 
-<p>Building a working AI agent swarm is the first step. Making it <em>good</em> is the next mountain.</p>
+<p data-i18n="ch8_p1">Building a working AI agent swarm is the first step. Making it <em>good</em> is the next mountain.</p>
 
-<h3>User Memory L0: Per-User Preferences</h3>
-<p>Project memory captures team-level lessons. But individual users have preferences: coding style, preferred frameworks, review standards. We need a <strong>User Memory L0</strong> layer that persists per-user context across projects.</p>
+<h3 data-i18n="ch8_h3_1">User Memory L0: Per-User Preferences</h3>
+<p data-i18n="ch8_p2">Project memory captures team-level lessons. But individual users have preferences: coding style, preferred frameworks, review standards. We need a <strong>User Memory L0</strong> layer that persists per-user context across projects.</p>
 
-<h3>Async Feedback Channel: True Human-in-the-Loop</h3>
-<p>Agents call <code>request_human_input</code> to pause; a question is posted on GitHub and a periodic checker resumes the agent when a human responds. The current 5-minute polling interval is coarse. We&rsquo;re exploring push-based mechanisms &mdash; webhooks from GitHub that trigger immediate resume.</p>
+<h3 data-i18n="ch8_h3_2">Async Feedback Channel: True Human-in-the-Loop</h3>
+<p data-i18n="ch8_p3">Agents call <code>request_human_input</code> to pause; a question is posted on GitHub and a periodic checker resumes the agent when a human responds. The current 5-minute polling interval is coarse. We&rsquo;re exploring push-based mechanisms &mdash; webhooks from GitHub that trigger immediate resume.</p>
 
-<h3>Priority System: Not All Tasks Are Equal</h3>
-<p>Right now, <code>ConcurrencyGovernor</code> treats all tasks as equal &mdash; first-come, first-served. A critical bug fix queues behind a low-priority documentation update. We need priority-aware scheduling.</p>
+<h3 data-i18n="ch8_h3_3">Priority System: Not All Tasks Are Equal</h3>
+<p data-i18n="ch8_p4">Right now, <code>ConcurrencyGovernor</code> treats all tasks as equal &mdash; first-come, first-served. A critical bug fix queues behind a low-priority documentation update. We need priority-aware scheduling.</p>
 
-<h3>Root Master Self-Delegation</h3>
-<p>The most radical unsolved problem. The Root Master Agent &mdash; the one you interact with directly in your IDE &mdash; is the most powerful and least controllable agent. Our proposed solution: the Root Master delegates all real work to a <code>master-orchestrator</code> role, making itself a thin dispatch layer subject to the same lifecycle as every other agent.</p>
+<h3 data-i18n="ch8_h3_4">Root Master Self-Delegation</h3>
+<p data-i18n="ch8_p5">The most radical unsolved problem. The Root Master Agent &mdash; the one you interact with directly in your IDE &mdash; is the most powerful and least controllable agent. Our proposed solution: the Root Master delegates all real work to a <code>master-orchestrator</code> role, making itself a thin dispatch layer subject to the same lifecycle as every other agent.</p>
 
-<h3>Multi-Engine Support: Beyond Claude Code</h3>
-<p>The real frontier is <strong>cross-model councils</strong>: a security review by Claude, a performance review by GPT, an architecture review by Gemini &mdash; all evaluating the same proposal from different model perspectives. The engine adapter pattern in <code>src/adapters/</code> already supports this.</p>
+<h3 data-i18n="ch8_h3_5">Multi-Engine Support: Beyond Claude Code</h3>
+<p data-i18n="ch8_p6">The real frontier is <strong>cross-model councils</strong>: a security review by Claude, a performance review by GPT, an architecture review by Gemini &mdash; all evaluating the same proposal from different model perspectives. The engine adapter pattern in <code>src/adapters/</code> already supports this.</p>
 
 <details class="deep-dive">
-  <summary>Deep Dive: The Meta-Problem</summary>
+  <summary data-i18n="ch8_dd1_summary">Deep Dive: The Meta-Problem</summary>
   <div class="deep-dive-content">
-    <p>Every improvement to Optimus is made by the swarm itself. When we dispatched a 5-expert council to audit the system&rsquo;s health, the council found 23 issues &mdash; including P0 bugs in the very infrastructure that spawned the council. The system is debugging itself.</p>
-    <p>How do you trust the output of a system that&rsquo;s auditing its own bugs? Our answer: <strong>cross-validation</strong>. When 2 out of 5 council members independently converge on the same P0 finding, confidence is high. When a finding comes from only one reviewer, it gets flagged for human verification.</p>
-    <p>The swarm doesn&rsquo;t need to be perfect. It needs to be honest about its imperfections &mdash; and equipped to fix them.</p>
+    <p data-i18n="ch8_dd1_p1">Every improvement to Optimus is made by the swarm itself. When we dispatched a 5-expert council to audit the system&rsquo;s health, the council found 23 issues &mdash; including P0 bugs in the very infrastructure that spawned the council. The system is debugging itself.</p>
+    <p data-i18n="ch8_dd1_p2">How do you trust the output of a system that&rsquo;s auditing its own bugs? Our answer: <strong>cross-validation</strong>. When 2 out of 5 council members independently converge on the same P0 finding, confidence is high. When a finding comes from only one reviewer, it gets flagged for human verification.</p>
+    <p data-i18n="ch8_dd1_p3">The swarm doesn&rsquo;t need to be perfect. It needs to be honest about its imperfections &mdash; and equipped to fix them.</p>
   </div>
 </details>
 </section>
@@ -671,23 +708,23 @@ ${content}
 <!-- ==================== CTA ==================== -->
 <section class="fade-section">
 <div class="cta-section">
-  <h2>Start Building Your Swarm</h2>
-  <p>Install Optimus Code and go from a single agent to a coordinated development team.</p>
+  <h2 data-i18n="cta_title">Start Building Your Swarm</h2>
+  <p data-i18n="cta_desc">Install Optimus Code and go from a single agent to a coordinated development team.</p>
   <div class="cta-install" id="ctaInstall">
     <span>npm install optimus-code</span>
-    <span class="cta-copy">Click to copy</span>
+    <span class="cta-copy" data-i18n="cta_copy">Click to copy</span>
   </div>
   <br>
   <div class="cta-links">
-    <a href="architecture.html" class="primary">Read the Architecture</a>
-    <a href="https://github.com/cloga/optimus-code" target="_blank" rel="noopener" class="secondary">View on GitHub</a>
+    <a href="architecture.html" class="primary" data-i18n="cta_arch">Read the Architecture</a>
+    <a href="https://github.com/cloga/optimus-code" target="_blank" rel="noopener" class="secondary" data-i18n="cta_github">View on GitHub</a>
   </div>
 </div>
 </section>
 
 <hr>
 
-<p><em>This guide is based on the real development history of <a href="https://github.com/cloga/optimus-code" target="_blank" rel="noopener">Optimus Code</a>, a self-evolving multi-agent orchestration engine built on the Model Context Protocol. Every bug, every postmortem, and every architectural decision described here happened.</em></p>
+<p data-i18n="guide_closing"><em>This guide is based on the real development history of <a href="https://github.com/cloga/optimus-code" target="_blank" rel="noopener">Optimus Code</a>, a self-evolving multi-agent orchestration engine built on the Model Context Protocol. Every bug, every postmortem, and every architectural decision described here happened.</em></p>
 
 </article>
 </div><!-- /page-wrapper -->
@@ -701,11 +738,11 @@ ${content}
 <footer>
   <div style="max-width:1140px;margin:0 auto;padding:0 24px">
     <div class="footer-links">
-      <a href="index.html">Home</a>
-      <a href="architecture.html">Architecture</a>
+      <a href="index.html" data-i18n="footer_home">Home</a>
+      <a href="architecture.html" data-i18n="footer_arch">Architecture</a>
       <a href="https://github.com/cloga/optimus-code" target="_blank" rel="noopener">GitHub</a>
     </div>
-    <div class="footer-tagline">Stop prompting. Start orchestrating.</div>
+    <div class="footer-tagline" data-i18n="footer_tagline">Stop prompting. Start orchestrating.</div>
   </div>
 </footer>
 
@@ -795,6 +832,35 @@ ${content}
     });
   },{threshold:0.08});
   document.querySelectorAll('.fade-section').forEach(function(s){obs.observe(s)});
+})();
+
+/* Hamburger menu toggle */
+(function(){
+  var btn=document.getElementById('hamburgerBtn');
+  var nav=document.getElementById('navLinks');
+  if(!btn||!nav)return;
+  btn.addEventListener('click',function(){
+    nav.classList.toggle('open');
+  });
+  nav.querySelectorAll('a').forEach(function(a){
+    a.addEventListener('click',function(){nav.classList.remove('open')});
+  });
+})();
+
+/* Language toggle */
+(function(){
+  var toggle=document.getElementById('langToggle');
+  if(!toggle)return;
+  var buttons=toggle.querySelectorAll('.lang-btn');
+  buttons.forEach(function(btn){
+    btn.addEventListener('click',function(){
+      buttons.forEach(function(b){b.classList.remove('active');b.setAttribute('aria-checked','false')});
+      btn.classList.add('active');
+      btn.setAttribute('aria-checked','true');
+      var lang=btn.getAttribute('data-lang');
+      if(typeof setLang==='function')setLang(lang);
+    });
+  });
 })();
 </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,25 +36,43 @@ a:hover{color:var(--accent)}
 
 .container{max-width:1100px;margin:0 auto;padding:0 24px}
 
-/* ========== LANGUAGE TOGGLE ========== */
+/* ========== NAV BAR ========== */
+.topnav{
+  position:sticky;top:0;z-index:100;
+  background:rgba(10,10,11,.85);
+  backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+  border-bottom:1px solid var(--border);
+  padding:14px 24px;
+}
+.topnav-inner{
+  max-width:1100px;margin:0 auto;
+  display:flex;align-items:center;justify-content:space-between;
+}
+.topnav-logo{font-weight:700;font-size:1rem;color:var(--text)}
+.topnav-logo:hover{color:var(--accent-hover)}
+.topnav-links{display:flex;gap:16px;align-items:center}
+.topnav-links a{font-size:.85rem;color:var(--text-tertiary);transition:color .2s}
+.topnav-links a:hover{color:var(--text)}
 .lang-toggle{
-  position:fixed;top:20px;right:20px;z-index:1000;
-  display:flex;align-items:center;
-  background:var(--surface);border:1px solid var(--border);border-radius:8px;
-  overflow:hidden;cursor:pointer;
-  box-shadow:0 4px 16px rgba(0,0,0,.3);
-  transition:border-color .2s;
+  display:inline-flex;align-items:center;
+  background:var(--bg);border:1px solid var(--border);border-radius:6px;
+  overflow:hidden;margin-left:8px;
 }
 .lang-toggle:hover{border-color:var(--accent)}
 .lang-btn{
-  padding:8px 14px;font-size:.8rem;font-weight:600;
+  padding:5px 10px;font-size:.75rem;font-weight:600;
   color:var(--text-tertiary);background:transparent;
   border:none;cursor:pointer;transition:all .2s;
   font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
 }
-.lang-btn.active{
-  color:#fff;background:var(--accent);
+.lang-btn.active{color:#fff;background:var(--accent)}
+/* Hamburger */
+.hamburger{
+  display:none;background:none;border:1px solid var(--border);
+  border-radius:6px;padding:6px 8px;cursor:pointer;color:var(--text);line-height:0;
 }
+.hamburger:hover{border-color:var(--accent)}
+.hamburger svg{display:block}
 
 /* ========== HERO ========== */
 .hero{
@@ -96,81 +114,38 @@ a:hover{color:var(--accent)}
 .tool-logos span{opacity:0;animation:fadeIn .5s ease forwards}
 .tool-logos span:hover{border-color:var(--accent)}
 
-/* Hero animation */
-.hero-animation{
-  width:100%;max-width:500px;height:300px;margin:0 auto 40px;position:relative;
+/* Hero terminal animation */
+.hero-terminal{
+  width:100%;max-width:600px;margin:0 auto 40px;
+  background:var(--code-bg);border:1px solid var(--border);border-radius:10px;
+  overflow:hidden;text-align:left;box-shadow:0 8px 40px rgba(0,0,0,.4);
 }
-.hero-animation svg{width:100%;height:100%}
-
-/* Master node */
-.master-node{
-  animation:pulse 3s ease-in-out infinite;
+.terminal-bar{
+  display:flex;align-items:center;gap:7px;
+  padding:10px 14px;background:var(--surface);border-bottom:1px solid var(--border);
 }
-@keyframes pulse{
-  0%,100%{filter:drop-shadow(0 0 8px rgba(59,130,246,.3))}
-  50%{filter:drop-shadow(0 0 20px rgba(59,130,246,.6))}
+.terminal-dot{width:10px;height:10px;border-radius:50%}
+.terminal-dot.red{background:#ff5f57}
+.terminal-dot.yellow{background:#febc2e}
+.terminal-dot.green{background:#28c840}
+.terminal-bar-title{
+  flex:1;text-align:center;font-size:.75rem;color:var(--text-tertiary);
+  font-family:'JetBrains Mono','Fira Code','Cascadia Code','Consolas',monospace;
 }
-
-/* Connection lines */
-.conn-line{
-  stroke-dasharray:200;
-  stroke-dashoffset:200;
-  animation:drawLine 2s ease forwards;
+.terminal-body{
+  padding:18px 22px;min-height:200px;
+  font-family:'JetBrains Mono','Fira Code','Cascadia Code','Consolas',monospace;
+  font-size:.85rem;line-height:1.7;
 }
-.conn-line:nth-child(1){animation-delay:0s}
-.conn-line:nth-child(2){animation-delay:.3s}
-.conn-line:nth-child(3){animation-delay:.6s}
-@keyframes drawLine{
-  to{stroke-dashoffset:0}
-}
-
-/* Agent nodes */
-.agent-node{
-  opacity:0;
-  animation:nodeAppear .6s ease forwards;
-}
-.agent-node:nth-of-type(1){animation-delay:1.5s}
-.agent-node:nth-of-type(2){animation-delay:1.8s}
-.agent-node:nth-of-type(3){animation-delay:2.1s}
-@keyframes nodeAppear{
-  from{opacity:0;transform:scale(.8)}
-  to{opacity:1;transform:scale(1)}
-}
-
-/* Data particles */
-.particle{
-  r:3;fill:var(--accent);opacity:0;
-}
-.particle-out{
-  animation:particleOut 4s ease-in-out infinite;
-}
-.particle-in{
-  animation:particleIn 4s ease-in-out infinite;
-}
-@keyframes particleOut{
-  0%{opacity:0;offset-distance:0%}
-  10%{opacity:1}
-  50%{opacity:1;offset-distance:100%}
-  51%{opacity:0}
-  100%{opacity:0}
-}
-@keyframes particleIn{
-  0%,50%{opacity:0;offset-distance:100%}
-  60%{opacity:1}
-  90%{opacity:1;offset-distance:0%}
-  91%{opacity:0}
-  100%{opacity:0}
-}
-
-/* Checkmark */
-.check-mark{
-  opacity:0;
-  animation:showCheck .5s ease forwards 12s;
-}
-@keyframes showCheck{
-  from{opacity:0;transform:scale(.5)}
-  to{opacity:1;transform:scale(1)}
-}
+.terminal-body .line{opacity:0;white-space:pre-wrap;word-break:break-word}
+.terminal-body .line.visible{opacity:1}
+.terminal-body .prompt{color:var(--accent-secondary)}
+.terminal-body .cmd{color:var(--text)}
+.terminal-body .info{color:var(--accent)}
+.terminal-body .ok{color:var(--accent-secondary)}
+.terminal-body .muted{color:var(--text-tertiary)}
+.terminal-body .blink{display:inline-block;animation:termBlink 1s step-end infinite}
+@keyframes termBlink{0%,50%{opacity:1}51%,100%{opacity:0}}
 
 /* CTA buttons */
 .cta-group{display:flex;justify-content:center;gap:16px;flex-wrap:wrap;margin-bottom:24px}
@@ -392,18 +367,6 @@ footer{
   content:'\2192';position:absolute;top:12px;right:-12px;
   font-size:1.1rem;color:var(--text-tertiary);z-index:2;
 }
-@keyframes fadeUp{
-  from{opacity:0;transform:translateY(24px)}
-  to{opacity:1;transform:translateY(0)}
-}
-.animate-on-scroll{opacity:0;transform:translateY(24px);transition:opacity .6s ease,transform .6s ease}
-.animate-on-scroll.visible{opacity:1;transform:translateY(0)}
-.stagger-1{transition-delay:.1s}
-.stagger-2{transition-delay:.2s}
-.stagger-3{transition-delay:.3s}
-.stagger-4{transition-delay:.4s}
-.stagger-5{transition-delay:.5s}
-.stagger-6{transition-delay:.6s}
 
 /* ========== ANIMATIONS ========== */
 @keyframes fadeIn{
@@ -438,11 +401,19 @@ footer{
   .eco-grid{grid-template-columns:repeat(2,1fr)}
   section{padding:80px 0}
   .hero{padding:60px 16px 40px}
-  .hero-animation{height:220px}
   .cta-group{flex-direction:column;align-items:center}
   .btn-primary,.btn-secondary{width:100%;max-width:280px;justify-content:center}
   .tier-flow{flex-direction:column;gap:0}
   .tier-arrow{transform:rotate(90deg);padding:8px 0}
+  /* Hamburger nav */
+  .topnav-links{
+    display:none;flex-direction:column;position:absolute;
+    top:100%;left:0;right:0;background:var(--surface);
+    border-bottom:1px solid var(--border);padding:16px 24px;gap:12px;
+  }
+  .topnav-links.open{display:flex}
+  .topnav-inner{position:relative}
+  .hamburger{display:block}
   /* Workflow vertical timeline */
   .workflow-pipeline{
     flex-direction:column;align-items:flex-start;gap:0;
@@ -485,11 +456,24 @@ footer{
 </head>
 <body>
 
-<!-- Language Toggle -->
-<div class="lang-toggle" id="langToggle" role="radiogroup" aria-label="Language selector">
-  <button class="lang-btn active" data-lang="en" role="radio" aria-checked="true">EN</button>
-  <button class="lang-btn" data-lang="zh" role="radio" aria-checked="false">中文</button>
-</div>
+<!-- Top Navigation -->
+<nav class="topnav">
+  <div class="topnav-inner">
+    <a href="index.html" class="topnav-logo">Optimus Code</a>
+    <button class="hamburger" id="hamburgerBtn" aria-label="Toggle navigation">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </button>
+    <div class="topnav-links" id="navLinks">
+      <a href="architecture.html" data-i18n="nav_architecture">Architecture</a>
+      <a href="guide.html" data-i18n="nav_tutorial">Tutorial</a>
+      <a href="https://github.com/cloga/optimus-code" target="_blank" rel="noopener">GitHub</a>
+      <div class="lang-toggle" id="langToggle" role="radiogroup" aria-label="Language selector">
+        <button class="lang-btn active" data-lang="en" role="radio" aria-checked="true">EN</button>
+        <button class="lang-btn" data-lang="zh" role="radio" aria-checked="false">中文</button>
+      </div>
+    </div>
+  </div>
+</nav>
 
 <!-- ==================== SECTION 1: HERO ==================== -->
 <section class="hero" id="hero">
@@ -506,58 +490,23 @@ footer{
       <span>Roo Cline</span>
     </div>
 
-    <!-- Hero SVG Animation: Master Agent delegates to 3 specialists -->
-    <div class="hero-animation" role="img" aria-label="Animation showing Master Agent delegating tasks to Architect, Developer, and QA specialists">
-      <svg viewBox="0 0 500 300" xmlns="http://www.w3.org/2000/svg">
-        <!-- Connection lines (drawn first, appear behind nodes) -->
-        <line class="conn-line" x1="250" y1="110" x2="100" y2="230" stroke="#3b82f6" stroke-width="1.5" stroke-opacity=".4"/>
-        <line class="conn-line" x1="250" y1="110" x2="250" y2="240" stroke="#3b82f6" stroke-width="1.5" stroke-opacity=".4"/>
-        <line class="conn-line" x1="250" y1="110" x2="400" y2="230" stroke="#3b82f6" stroke-width="1.5" stroke-opacity=".4"/>
-
-        <!-- Master Agent node (center top) -->
-        <g class="master-node">
-          <circle cx="250" cy="90" r="36" fill="#141416" stroke="#3b82f6" stroke-width="2"/>
-          <text x="250" y="85" text-anchor="middle" fill="#e4e4e7" font-size="11" font-weight="600" font-family="Inter,sans-serif" data-i18n="svg_master">Master</text>
-          <text x="250" y="99" text-anchor="middle" fill="#a1a1aa" font-size="9" font-family="Inter,sans-serif" data-i18n="svg_agent">Agent</text>
-        </g>
-
-        <!-- Architect node -->
-        <g class="agent-node" style="animation-delay:1.5s">
-          <circle cx="100" cy="240" r="30" fill="#141416" stroke="#8b5cf6" stroke-width="2"/>
-          <text x="100" y="237" text-anchor="middle" fill="#e4e4e7" font-size="10" font-weight="600" font-family="Inter,sans-serif" data-i18n="svg_architect">Architect</text>
-          <text x="100" y="250" text-anchor="middle" fill="#a1a1aa" font-size="8" font-family="Inter,sans-serif" data-i18n="svg_design">design</text>
-        </g>
-
-        <!-- Developer node -->
-        <g class="agent-node" style="animation-delay:1.8s">
-          <circle cx="250" cy="250" r="30" fill="#141416" stroke="#10b981" stroke-width="2"/>
-          <text x="250" y="247" text-anchor="middle" fill="#e4e4e7" font-size="10" font-weight="600" font-family="Inter,sans-serif" data-i18n="svg_developer">Developer</text>
-          <text x="250" y="260" text-anchor="middle" fill="#a1a1aa" font-size="8" font-family="Inter,sans-serif" data-i18n="svg_build">build</text>
-        </g>
-
-        <!-- QA node -->
-        <g class="agent-node" style="animation-delay:2.1s">
-          <circle cx="400" cy="240" r="30" fill="#141416" stroke="#f59e0b" stroke-width="2"/>
-          <text x="400" y="237" text-anchor="middle" fill="#e4e4e7" font-size="10" font-weight="600" font-family="Inter,sans-serif">QA</text>
-          <text x="400" y="250" text-anchor="middle" fill="#a1a1aa" font-size="8" font-family="Inter,sans-serif" data-i18n="svg_verify">verify</text>
-        </g>
-
-        <!-- Outbound particles (data flowing to agents) -->
-        <circle class="particle particle-out" style="offset-path:path('M250,110 L100,230');animation-delay:3s;fill:#8b5cf6"/>
-        <circle class="particle particle-out" style="offset-path:path('M250,110 L250,240');animation-delay:3.3s;fill:#10b981"/>
-        <circle class="particle particle-out" style="offset-path:path('M250,110 L400,230');animation-delay:3.6s;fill:#f59e0b"/>
-
-        <!-- Return particles (results flowing back) -->
-        <circle class="particle particle-in" style="offset-path:path('M250,110 L100,230');animation-delay:4s;fill:#8b5cf6"/>
-        <circle class="particle particle-in" style="offset-path:path('M250,110 L250,240');animation-delay:4.3s;fill:#10b981"/>
-        <circle class="particle particle-in" style="offset-path:path('M250,110 L400,230');animation-delay:4.6s;fill:#f59e0b"/>
-
-        <!-- Success checkmark -->
-        <g class="check-mark" transform="translate(250,90)">
-          <circle r="14" fill="#10b981" opacity=".2"/>
-          <path d="M-5,0 L-1,4 L6,-4" fill="none" stroke="#10b981" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
-        </g>
-      </svg>
+    <!-- Animated Terminal Hero -->
+    <div class="hero-terminal" role="img" aria-label="Animated terminal showing Optimus orchestrating an agent swarm">
+      <div class="terminal-bar">
+        <span class="terminal-dot red"></span>
+        <span class="terminal-dot yellow"></span>
+        <span class="terminal-dot green"></span>
+        <span class="terminal-bar-title">optimus &mdash; swarm</span>
+      </div>
+      <div class="terminal-body" id="terminalBody">
+        <div class="line" data-delay="300"><span class="prompt">$ </span><span class="cmd">optimus dispatch &quot;Add dark-mode toggle&quot;</span></div>
+        <div class="line" data-delay="900"><span class="info">[Master]</span> <span class="muted" data-i18n="term_analyzing">Analyzing request&hellip;</span></div>
+        <div class="line" data-delay="1500"><span class="info">[Master]</span> <span class="muted" data-i18n="term_spawning">Spawning council: Architect + Dev + QA</span></div>
+        <div class="line" data-delay="2200"><span class="ok">[Architect]</span> <span class="muted" data-i18n="term_design">Design proposal written &rarr; .optimus/proposals/</span></div>
+        <div class="line" data-delay="2900"><span class="ok">[Developer]</span> <span class="muted" data-i18n="term_impl">Implementation complete &mdash; 4 files changed</span></div>
+        <div class="line" data-delay="3600"><span class="ok">[QA]</span> <span class="muted" data-i18n="term_tests">All tests passing (12/12)</span></div>
+        <div class="line" data-delay="4300"><span class="info">[Master]</span> <span class="ok" data-i18n="term_pr">PR #42 created &amp; merged</span> <span class="blink">&#9608;</span></div>
+      </div>
     </div>
 
     <div class="cta-group">
@@ -873,7 +822,7 @@ footer{
       <a href="https://github.com/cloga/optimus-code" target="_blank" rel="noopener">GitHub</a>
       <a href="https://github.com/cloga/optimus-code#readme" target="_blank" rel="noopener" data-i18n="footer_docs">Documentation</a>
       <a href="architecture.html" data-i18n="footer_arch">Architecture</a>
-      <a href="guide.html">Tutorial</a>
+      <a href="guide.html" data-i18n="nav_tutorial">Tutorial</a>
       <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener" data-i18n="footer_license">MIT License</a>
     </div>
     <div class="footer-tagline" data-i18n="footer_tagline">Stop prompting. Start orchestrating.</div>
@@ -884,10 +833,18 @@ footer{
 /* Translation dictionary */
 var i18n={
   en:{
+    nav_architecture:"Architecture",
+    nav_tutorial:"Tutorial",
     hero_title:"Your AI coding tool's operating system",
     hero_subtitle:"Turn one AI assistant into a coordinated dev team. Works with Cursor, Claude Code, Copilot, Windsurf, and any MCP client.",
     hero_cta_start:"Get Started",
     copied:"Copied!",
+    term_analyzing:"Analyzing request\u2026",
+    term_spawning:"Spawning council: Architect + Dev + QA",
+    term_design:"Design proposal written \u2192 .optimus/proposals/",
+    term_impl:"Implementation complete \u2014 4 files changed",
+    term_tests:"All tests passing (12/12)",
+    term_pr:"PR #42 created & merged",
     how_title:"How It Works",
     how_subtitle:"A self-evolving agent lifecycle",
     how_orchestrate_title:"Orchestrate",
@@ -965,20 +922,21 @@ var i18n={
     footer_arch:"Architecture",
     footer_license:"MIT License",
     footer_tagline:"Stop prompting. Start orchestrating.",
-    svg_master:"Master",
-    svg_agent:"Agent",
-    svg_architect:"Architect",
-    svg_design:"design",
-    svg_developer:"Developer",
-    svg_build:"build",
-    svg_verify:"verify",
     scroll_down:"Scroll"
   },
   zh:{
+    nav_architecture:"\u67B6\u6784",
+    nav_tutorial:"\u6559\u7A0B",
     hero_title:"\u4F60\u7684 AI \u7F16\u7801\u5DE5\u5177\u7684\u64CD\u4F5C\u7CFB\u7EDF",
     hero_subtitle:"\u5C06\u4E00\u4E2A AI \u52A9\u624B\u8F6C\u53D8\u4E3A\u534F\u8C03\u7684\u5F00\u53D1\u56E2\u961F\u3002\u652F\u6301 Cursor\u3001Claude Code\u3001Copilot\u3001Windsurf \u53CA\u4EFB\u4F55 MCP \u5BA2\u6237\u7AEF\u3002",
     hero_cta_start:"\u5F00\u59CB\u4F7F\u7528",
     copied:"\u5DF2\u590D\u5236\uFF01",
+    term_analyzing:"\u5206\u6790\u8BF7\u6C42\u4E2D\u2026",
+    term_spawning:"\u542F\u52A8\u59D4\u5458\u4F1A\uFF1A\u67B6\u6784\u5E08 + \u5F00\u53D1\u8005 + QA",
+    term_design:"\u8BBE\u8BA1\u63D0\u6848\u5DF2\u5199\u5165 \u2192 .optimus/proposals/",
+    term_impl:"\u5B9E\u73B0\u5B8C\u6210 \u2014 4 \u4E2A\u6587\u4EF6\u5DF2\u4FEE\u6539",
+    term_tests:"\u6240\u6709\u6D4B\u8BD5\u901A\u8FC7 (12/12)",
+    term_pr:"PR #42 \u5DF2\u521B\u5EFA\u5E76\u5408\u5E76",
     how_title:"\u5DE5\u4F5C\u539F\u7406",
     how_subtitle:"\u81EA\u8FDB\u5316\u7684\u667A\u80FD\u4F53\u751F\u547D\u5468\u671F",
     how_orchestrate_title:"\u7F16\u6392",
@@ -1056,13 +1014,6 @@ var i18n={
     footer_arch:"\u67B6\u6784",
     footer_license:"MIT \u8BB8\u53EF\u8BC1",
     footer_tagline:"\u505C\u6B62\u63D0\u793A\u8BCD\u5DE5\u7A0B\u3002\u5F00\u59CB\u7F16\u6392\u3002",
-    svg_master:"\u4E3B\u63A7",
-    svg_agent:"\u667A\u80FD\u4F53",
-    svg_architect:"\u67B6\u6784\u5E08",
-    svg_design:"\u8BBE\u8BA1",
-    svg_developer:"\u5F00\u53D1\u8005",
-    svg_build:"\u6784\u5EFA",
-    svg_verify:"\u9A8C\u8BC1",
     scroll_down:"\u4E0B\u6ED1"
   }
 };
@@ -1115,6 +1066,30 @@ function setLang(lang){
     if(lang&&lang!==currentLang){
       setLang(lang);
     }
+  });
+})();
+
+/* Hamburger menu toggle */
+(function(){
+  var btn=document.getElementById('hamburgerBtn');
+  var nav=document.getElementById('navLinks');
+  if(!btn||!nav)return;
+  btn.addEventListener('click',function(){
+    nav.classList.toggle('open');
+  });
+  /* Close on link click */
+  nav.querySelectorAll('a').forEach(function(a){
+    a.addEventListener('click',function(){nav.classList.remove('open')});
+  });
+})();
+
+/* Terminal typewriter animation */
+(function(){
+  var lines=document.querySelectorAll('#terminalBody .line');
+  if(!lines.length)return;
+  lines.forEach(function(line){
+    var delay=parseInt(line.getAttribute('data-delay'),10)||0;
+    setTimeout(function(){line.classList.add('visible')},delay);
   });
 })();
 


### PR DESCRIPTION
## Summary

- **Animated terminal hero** replaces the SVG animation on `index.html` — shows a typewriter-style agent orchestration workflow (dispatch → council → implement → merge)
- **Sticky top navbar** with cross-page navigation (Architecture, Tutorial, GitHub) and inline language toggle replaces the old floating fixed-position language switcher across all 3 docs pages
- **Mobile hamburger menu** for responsive navigation on small screens
- **Unified `max-width:1100px`** on navbar containers across `index.html`, `architecture.html`, and `guide.html`
- **New i18n keys** added for EN/ZH: `nav_architecture`, `nav_tutorial`, `term_analyzing`, `term_spawning`, `term_design`, `term_impl`, `term_tests`, `term_pr`

## Test plan

- [ ] Open `docs/index.html` in browser — verify animated terminal with typewriter effect
- [ ] Verify navbar links (Architecture, Tutorial, GitHub) navigate correctly
- [ ] Toggle EN/ZH language and verify all new strings translate
- [ ] Resize to mobile width (<768px) — verify hamburger menu appears and works
- [ ] Open `docs/architecture.html` — verify consistent navbar (no "Architecture" self-link)
- [ ] Open `docs/guide.html` — verify consistent navbar (no "Tutorial" self-link)
- [ ] Verify no floating language toggle remains on any page

Fixes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_🤖 Created by `master-orchestrator` via Optimus Spartan Swarm_