### PR TITLE
[Optimus] feat: implement multi-level memory system with priority-based loading

### DIFF
--- a/src/managers/MemoryManager.ts
+++ b/src/managers/MemoryManager.ts
@@ -1,0 +1,579 @@
+/**
+ * MemoryManager — Multi-Level Memory System
+ *
+ * Owns all memory loading, parsing, scoring, and migration logic.
+ * Supports project-level and role-level memory scopes with
+ * priority-based filtering within a token budget.
+ */
+import fs from 'fs';
+import path from 'path';
+
+// ─── Types ───
+
+export interface MemoryEntry {
+    id: string;
+    date: string;
+    level: 'project' | 'role';
+    category: string;
+    tags: string[];
+    author: string;
+    body: string;
+}
+
+// ─── Role Name Sanitization (mirrors worker-spawner.ts:68-70) ───
+
+function sanitizeRoleName(role: string): string {
+    return role.replace(/[^a-zA-Z0-9_-]/g, '').substring(0, 100);
+}
+
+// ─── YAML Frontmatter Parser ───
+
+/**
+ * Parse multi-document markdown with YAML frontmatter blocks.
+ * Each entry is delimited by paired `---` lines. Text without
+ * frontmatter is wrapped as a legacy entry.
+ *
+ * Never throws — malformed entries are skipped or wrapped as legacy.
+ */
+export function parseMemoryEntries(content: string): MemoryEntry[] {
+    if (content === undefined || content === null) return [];
+    const trimmed = content.trim();
+    if (!trimmed) return [];
+
+    const entries: MemoryEntry[] = [];
+    const lines = trimmed.split('\n');
+    let i = 0;
+
+    // Collect unstructured text that appears before/between frontmatter blocks
+    let unstructuredBuffer: string[] = [];
+
+    function flushUnstructured(): void {
+        const text = unstructuredBuffer.join('\n').trim();
+        if (text) {
+            entries.push({
+                id: 'legacy_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8),
+                date: new Date().toISOString(),
+                level: 'project',
+                category: 'legacy',
+                tags: ['unstructured'],
+                author: 'system',
+                body: text,
+            });
+        }
+        unstructuredBuffer = [];
+    }
+
+    while (i < lines.length) {
+        // Check for frontmatter opening delimiter
+        if (lines[i].trim() === '---') {
+            const fmStart = i + 1;
+            // Find closing delimiter
+            let fmEnd = -1;
+            for (let j = fmStart; j < lines.length; j++) {
+                if (lines[j].trim() === '---') {
+                    fmEnd = j;
+                    break;
+                }
+            }
+
+            if (fmEnd === -1) {
+                // No closing delimiter — treat rest as unstructured
+                unstructuredBuffer.push(lines[i]);
+                i++;
+                continue;
+            }
+
+            // Try to parse the frontmatter as YAML key-value pairs
+            const fmLines = lines.slice(fmStart, fmEnd);
+            const parsed = parseSimpleYaml(fmLines);
+
+            if (parsed === null) {
+                // Not valid YAML key-value — treat as unstructured text
+                unstructuredBuffer.push(lines[i]);
+                i++;
+                continue;
+            }
+
+            // Flush any preceding unstructured text as a legacy entry
+            flushUnstructured();
+
+            // Collect body text until next frontmatter block or EOF
+            let bodyStart = fmEnd + 1;
+            let bodyEnd = bodyStart;
+            while (bodyEnd < lines.length) {
+                // Look ahead for next frontmatter opening
+                if (lines[bodyEnd].trim() === '---') {
+                    // Check if this is the start of a new frontmatter block
+                    let nextClose = -1;
+                    for (let k = bodyEnd + 1; k < lines.length; k++) {
+                        if (lines[k].trim() === '---') {
+                            nextClose = k;
+                            break;
+                        }
+                    }
+                    if (nextClose !== -1) {
+                        const candidateFm = lines.slice(bodyEnd + 1, nextClose);
+                        if (parseSimpleYaml(candidateFm) !== null) {
+                            break; // This is a real frontmatter block
+                        }
+                    }
+                }
+                bodyEnd++;
+            }
+
+            const bodyText = lines.slice(bodyStart, bodyEnd).join('\n').trim();
+
+            entries.push({
+                id: parsed.id || 'unknown_' + Date.now(),
+                date: parsed.date || parsed.created || '',
+                level: (parsed.level === 'role' ? 'role' : 'project'),
+                category: parsed.category || 'uncategorized',
+                tags: parseTags(parsed.tags),
+                author: parsed.author || 'unknown',
+                body: bodyText,
+            });
+
+            i = bodyEnd;
+        } else {
+            unstructuredBuffer.push(lines[i]);
+            i++;
+        }
+    }
+
+    // Flush any trailing unstructured text
+    flushUnstructured();
+
+    return entries;
+}
+
+/**
+ * Parse simple YAML key-value lines (no nesting).
+ * Returns null if the content doesn't look like valid frontmatter.
+ */
+function parseSimpleYaml(lines: string[]): Record<string, string> | null {
+    if (lines.length === 0) return null;
+
+    const result: Record<string, string> = {};
+    let hasValidKey = false;
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue; // blank lines OK
+
+        const colonIdx = trimmed.indexOf(':');
+        if (colonIdx <= 0) return null; // Not a key-value line
+
+        const key = trimmed.substring(0, colonIdx).trim();
+        const value = trimmed.substring(colonIdx + 1).trim();
+
+        // Validate key is a simple identifier
+        if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)) return null;
+
+        result[key] = value;
+        hasValidKey = true;
+    }
+
+    return hasValidKey ? result : null;
+}
+
+/**
+ * Parse tags from a YAML array value like `[tag1, tag2]` or a bare string.
+ */
+function parseTags(raw: string | undefined): string[] {
+    if (!raw) return [];
+    const trimmed = raw.trim();
+
+    // Handle bracket-delimited array: [tag1, tag2, tag3]
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+        return trimmed
+            .slice(1, -1)
+            .split(',')
+            .map(t => t.trim())
+            .filter(t => t.length > 0);
+    }
+
+    // Otherwise treat as a single tag
+    return trimmed ? [trimmed] : [];
+}
+
+// ─── Relevance Scoring ───
+
+/**
+ * Score a memory entry for relevance to the current role.
+ * - +3 if tags or category match role name (case-insensitive substring)
+ * - +2 if dated within last 7 days
+ * - +1 if dated within last 30 days
+ */
+export function scoreEntry(entry: MemoryEntry, currentRole: string): number {
+    let score = 0;
+    const roleLower = currentRole.toLowerCase();
+
+    // Role match: check tags and category
+    if (roleLower) {
+        const categoryMatch = entry.category.toLowerCase().includes(roleLower);
+        const tagMatch = entry.tags.some(t => t.toLowerCase().includes(roleLower));
+        if (categoryMatch || tagMatch) {
+            score += 3;
+        }
+    }
+
+    // Recency scoring
+    if (entry.date) {
+        try {
+            const entryDate = new Date(entry.date);
+            const now = new Date();
+            const diffMs = now.getTime() - entryDate.getTime();
+            const diffDays = diffMs / (1000 * 60 * 60 * 24);
+
+            if (diffDays <= 7) {
+                score += 2;
+            } else if (diffDays <= 30) {
+                score += 1;
+            }
+        } catch {
+            // Invalid date — no recency bonus
+        }
+    }
+
+    return score;
+}
+
+// ─── Tiered Greedy-Fill Loader ───
+
+/**
+ * Load and filter memory entries from both project and role files.
+ * Uses tiered greedy-fill:
+ *   1. Reserve ~2000 chars for top project-level entries
+ *   2. Fill ~6000 chars with role-specific entries
+ *   3. Fill remainder with all remaining entries
+ *
+ * Returns body text only (no frontmatter), concatenated with `\n\n`.
+ * Never throws — returns empty string on any error.
+ */
+export function loadFilteredMemory(
+    workspacePath: string,
+    currentRole: string,
+    maxChars: number = 16000
+): string {
+    try {
+        const allEntries: MemoryEntry[] = [];
+
+        // Read project-level memory
+        const projectFile = path.join(workspacePath, '.optimus', 'memory', 'continuous-memory.md');
+        if (fs.existsSync(projectFile)) {
+            try {
+                const raw = fs.readFileSync(projectFile, 'utf8');
+                allEntries.push(...parseMemoryEntries(raw));
+            } catch {
+                // Best-effort
+            }
+        }
+
+        // Read role-level memory
+        const sanitizedRole = sanitizeRoleName(currentRole);
+        if (sanitizedRole) {
+            const roleFile = path.join(workspacePath, '.optimus', 'memory', 'roles', `${sanitizedRole}.md`);
+            if (fs.existsSync(roleFile)) {
+                try {
+                    const raw = fs.readFileSync(roleFile, 'utf8');
+                    const roleEntries = parseMemoryEntries(raw);
+                    // Mark these as role-level
+                    for (const entry of roleEntries) {
+                        entry.level = 'role';
+                    }
+                    allEntries.push(...roleEntries);
+                } catch {
+                    // Best-effort
+                }
+            }
+        }
+
+        if (allEntries.length === 0) return '';
+
+        // Score all entries
+        const scored = allEntries.map(entry => ({
+            entry,
+            score: scoreEntry(entry, currentRole),
+        }));
+
+        // Sort by score desc, then date desc
+        scored.sort((a, b) => {
+            if (b.score !== a.score) return b.score - a.score;
+            // Date descending (newer first)
+            return (b.entry.date || '').localeCompare(a.entry.date || '');
+        });
+
+        // Tier budgets
+        const projectReserve = Math.min(2000, maxChars);
+        const roleBudget = Math.min(6000, maxChars - projectReserve);
+        const openBudget = maxChars - projectReserve - roleBudget;
+
+        const selected: string[] = [];
+        const used = new Set<number>(); // track indices of selected entries
+        let projectUsed = 0;
+        let roleUsed = 0;
+        let openUsed = 0;
+
+        // Tier 1: Top project-level entries (foundational rules)
+        const projectEntries = scored.filter(s => s.entry.level === 'project');
+        for (let idx = 0; idx < projectEntries.length; idx++) {
+            const body = projectEntries[idx].entry.body;
+            if (!body) continue;
+            if (projectUsed + body.length + 2 > projectReserve) break;
+            selected.push(body);
+            projectUsed += body.length + 2;
+            used.add(scored.indexOf(projectEntries[idx]));
+        }
+
+        // Tier 2: Role-specific entries by score desc, then date desc
+        const roleEntries = scored.filter(s => s.entry.level === 'role');
+        for (let idx = 0; idx < roleEntries.length; idx++) {
+            const body = roleEntries[idx].entry.body;
+            if (!body) continue;
+            if (roleUsed + body.length + 2 > roleBudget) continue; // try smaller entries
+            selected.push(body);
+            roleUsed += body.length + 2;
+            used.add(scored.indexOf(roleEntries[idx]));
+        }
+
+        // Tier 3: All remaining entries by score
+        for (let idx = 0; idx < scored.length; idx++) {
+            if (used.has(idx)) continue;
+            const body = scored[idx].entry.body;
+            if (!body) continue;
+            if (openUsed + body.length + 2 > openBudget) continue; // try smaller entries
+            selected.push(body);
+            openUsed += body.length + 2;
+        }
+
+        return selected.join('\n\n').trim();
+    } catch {
+        return ''; // Silent fail — memory injection is best-effort
+    }
+}
+
+// ─── Legacy Migration ───
+
+/**
+ * Migrate an existing memory file by wrapping unstructured text
+ * in YAML frontmatter blocks.
+ *
+ * Idempotent: checks for `.migrated` marker file.
+ * Atomic: writes to `.tmp` then renames.
+ */
+export function migrateMemoryFile(filePath: string): void {
+    try {
+        const markerFile = filePath + '.migrated';
+        if (fs.existsSync(markerFile)) return; // Already migrated
+
+        if (!fs.existsSync(filePath)) return; // Nothing to migrate
+
+        const raw = fs.readFileSync(filePath, 'utf8');
+        if (!raw.trim()) return; // Empty file
+
+        // Parse to see what we have
+        const entries = parseMemoryEntries(raw);
+
+        // Check if all entries already have proper frontmatter (no legacy entries)
+        const hasLegacy = entries.some(e => e.category === 'legacy');
+        if (!hasLegacy) {
+            // File is already fully structured — just create the marker
+            fs.writeFileSync(markerFile, new Date().toISOString(), 'utf8');
+            return;
+        }
+
+        // Get file mtime for legacy entry dates
+        let mtime: string;
+        try {
+            const stat = fs.statSync(filePath);
+            mtime = stat.mtime.toISOString();
+        } catch {
+            mtime = new Date().toISOString();
+        }
+
+        // Re-read and rebuild: structured entries stay as-is, unstructured gets wrapped
+        const lines = raw.split('\n');
+        const outputParts: string[] = [];
+        let i = 0;
+        let unstructuredBuffer: string[] = [];
+
+        function flushUnstructuredToOutput(): void {
+            const text = unstructuredBuffer.join('\n').trim();
+            if (text) {
+                const legacyId = 'legacy_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
+                outputParts.push(
+                    '---\n' +
+                    `id: ${legacyId}\n` +
+                    `date: ${mtime}\n` +
+                    'level: project\n' +
+                    'category: legacy\n' +
+                    'tags: [unstructured, migrated]\n' +
+                    'author: system\n' +
+                    '---\n' +
+                    text
+                );
+            }
+            unstructuredBuffer = [];
+        }
+
+        while (i < lines.length) {
+            if (lines[i].trim() === '---') {
+                const fmStart = i + 1;
+                let fmEnd = -1;
+                for (let j = fmStart; j < lines.length; j++) {
+                    if (lines[j].trim() === '---') {
+                        fmEnd = j;
+                        break;
+                    }
+                }
+
+                if (fmEnd !== -1) {
+                    const fmLines = lines.slice(fmStart, fmEnd);
+                    const parsed = parseSimpleYaml(fmLines);
+
+                    if (parsed !== null) {
+                        // Valid frontmatter block — flush unstructured, then copy block as-is
+                        flushUnstructuredToOutput();
+
+                        // Find body end
+                        let bodyEnd = fmEnd + 1;
+                        while (bodyEnd < lines.length) {
+                            if (lines[bodyEnd].trim() === '---') {
+                                let nextClose = -1;
+                                for (let k = bodyEnd + 1; k < lines.length; k++) {
+                                    if (lines[k].trim() === '---') {
+                                        nextClose = k;
+                                        break;
+                                    }
+                                }
+                                if (nextClose !== -1) {
+                                    const candidateFm = lines.slice(bodyEnd + 1, nextClose);
+                                    if (parseSimpleYaml(candidateFm) !== null) {
+                                        break;
+                                    }
+                                }
+                            }
+                            bodyEnd++;
+                        }
+
+                        // Copy original block verbatim
+                        outputParts.push(lines.slice(i, bodyEnd).join('\n'));
+                        i = bodyEnd;
+                        continue;
+                    }
+                }
+
+                // Not valid frontmatter — treat as unstructured
+                unstructuredBuffer.push(lines[i]);
+                i++;
+            } else {
+                unstructuredBuffer.push(lines[i]);
+                i++;
+            }
+        }
+
+        flushUnstructuredToOutput();
+
+        const output = outputParts.join('\n\n') + '\n';
+
+        // Atomic write: tmp file then rename
+        const tmpFile = filePath + '.tmp';
+        fs.writeFileSync(tmpFile, output, 'utf8');
+        fs.renameSync(tmpFile, filePath);
+
+        // Create migration marker
+        fs.writeFileSync(markerFile, new Date().toISOString(), 'utf8');
+    } catch (e: any) {
+        console.error(`[MemoryManager] Migration failed for ${filePath}: ${e.message}`);
+        // Non-fatal — memory loading will still work on the unmigrated file
+    }
+}
+
+// ─── Entry Builder ───
+
+/**
+ * Build a formatted memory entry string with YAML frontmatter.
+ * Ready to append to a memory file.
+ */
+export function buildMemoryEntry(params: {
+    level: 'project' | 'role';
+    category: string;
+    tags: string[];
+    content: string;
+    author: string;
+}): string {
+    const id = 'mem_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
+    const date = new Date().toISOString();
+    const tagsStr = params.tags && params.tags.length > 0
+        ? '[' + params.tags.join(', ') + ']'
+        : '[]';
+
+    return [
+        '---',
+        `id: ${id}`,
+        `date: ${date}`,
+        `level: ${params.level}`,
+        `category: ${params.category || 'uncategorized'}`,
+        `tags: ${tagsStr}`,
+        `author: ${params.author}`,
+        '---',
+        params.content,
+        '\n',
+    ].join('\n');
+}
+
+// ─── File Path Resolution ───
+
+/**
+ * Get the memory file path for a given scope.
+ * For "role": sanitizes role name, ensures roles dir exists,
+ * validates resolved path is under the roles directory.
+ */
+export function getMemoryFilePath(
+    workspacePath: string,
+    level: 'project' | 'role',
+    role?: string
+): string {
+    if (level === 'project') {
+        return path.join(workspacePath, '.optimus', 'memory', 'continuous-memory.md');
+    }
+
+    // level === 'role'
+    if (!role) {
+        throw new Error('Role name is required for role-level memory');
+    }
+
+    const sanitized = sanitizeRoleName(role);
+    if (!sanitized) {
+        throw new Error(`Invalid role name after sanitization: '${role}'`);
+    }
+
+    const rolesDir = path.join(workspacePath, '.optimus', 'memory', 'roles');
+
+    // Ensure directory exists
+    if (!fs.existsSync(rolesDir)) {
+        fs.mkdirSync(rolesDir, { recursive: true });
+    }
+
+    const targetFile = path.join(rolesDir, `${sanitized}.md`);
+
+    // Security validation: lexical check
+    const resolvedTarget = path.resolve(targetFile);
+    const resolvedRolesDir = path.resolve(rolesDir);
+    if (!resolvedTarget.startsWith(resolvedRolesDir + path.sep) && resolvedTarget !== resolvedRolesDir) {
+        throw new Error(`Path traversal detected: resolved path '${resolvedTarget}' is outside roles directory`);
+    }
+
+    // Security validation: realpathSync on the existing parent directory
+    try {
+        const realRolesDir = fs.realpathSync(rolesDir);
+        if (!resolvedTarget.startsWith(realRolesDir + path.sep)) {
+            throw new Error(`Symlink traversal detected: real path of roles dir is '${realRolesDir}'`);
+        }
+    } catch (e: any) {
+        if (e.message && e.message.includes('traversal')) throw e;
+        // realpathSync may fail if dir was just created — lexical check is still in place
+    }
+
+    return targetFile;
+}

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -13,6 +13,7 @@ import path from "path";
 import os from "os";
 import crypto from "crypto";
 import { dispatchCouncilConcurrent, delegateTaskSingle, loadValidEnginesAndModels, isValidEngine, isValidModel, updateFrontmatter, loadT3UsageLog, saveT3UsageLog } from "./worker-spawner";
+import { getMemoryFilePath, buildMemoryEntry } from "../managers/MemoryManager";
 import { cleanStaleAgents } from "./agent-gc";
 import { TaskManifestManager } from "../managers/TaskManifestManager";
 import { parseGitRemote, createGitHubIssue } from "../utils/githubApi";
@@ -122,7 +123,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             properties: {
               category: { type: "string", description: "The category of the memory (e.g. 'architecture-decision', 'bug-fix', 'workflow')" },
               tags: { type: "array", items: { type: "string" }, description: "A list of tags for selective loading" },
-              content: { type: "string", description: "The actual memory content to solidify" }
+              content: { type: "string", description: "The actual memory content to solidify" },
+              level: { type: "string", description: "Memory scope: 'project' for shared context, 'role' for role-specific. Defaults to project.", enum: ["project", "role"] }
             },
             required: ["category", "tags", "content"]
           }
@@ -766,12 +768,29 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       ],
     };
         } else if (request.params.name === "append_memory") {
-      let { category, tags, content } = request.params.arguments as any;
+      let { category, tags, content, level } = request.params.arguments as any;
       requireParams("append_memory", request.params.arguments as any, ["category", "content"]);
       const workspacePath = process.env.OPTIMUS_WORKSPACE_ROOT || process.cwd();
-      const memoryDir = path.resolve(workspacePath, '.optimus', 'memory');
-      const memoryFile = path.join(memoryDir, 'continuous-memory.md');
+      const memoryLevel: 'project' | 'role' = level === 'role' ? 'role' : 'project';
+      const author = process.env.OPTIMUS_CURRENT_ROLE || 'unknown';
 
+      // Determine target file based on level
+      let memoryFile: string;
+      if (memoryLevel === 'role') {
+        const currentRole = process.env.OPTIMUS_CURRENT_ROLE;
+        if (!currentRole) {
+          return {
+            content: [{ type: "text", text: "Cannot write role-level memory: OPTIMUS_CURRENT_ROLE not set. Use level: 'project' or ensure this is called from a delegated worker." }],
+            isError: true
+          };
+        }
+        memoryFile = getMemoryFilePath(workspacePath, 'role', currentRole);
+      } else {
+        memoryFile = getMemoryFilePath(workspacePath, 'project');
+      }
+
+      // Ensure parent directory exists
+      const memoryDir = path.dirname(memoryFile);
       if (!fs.existsSync(memoryDir)) {
         fs.mkdirSync(memoryDir, { recursive: true });
       }
@@ -787,19 +806,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         // Create new write promise
         const writePromise = new Promise<void>((resolve, reject) => {
           try {
-            const timestamp = new Date().toISOString();
-            const memoryId = 'mem_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
-            
-            const freshEntry = [
-              '---',
-              'id: ' + memoryId,
-              'category: ' + (category || 'uncategorized'),
-              'tags: [' + (tags ? tags.join(', ') : '') + ']',
-              'created: ' + timestamp,
-              '---',
-              content,
-              '\n'
-            ].join('\n');
+            const freshEntry = buildMemoryEntry({
+              level: memoryLevel,
+              category: category || 'uncategorized',
+              tags: tags || [],
+              content: content,
+              author: author,
+            });
 
             fs.appendFileSync(memoryFile, freshEntry, 'utf8');
             resolve();
@@ -807,15 +820,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             reject(err);
           }
         });
-        
+
         (global as any).memoryLock = writePromise;
         await writePromise;
-        
+
         return {
           content: [
             {
               type: "text",
-              text: `✅ Experience solidifed to memory!\nTags: ${tags.join(', ')}\nMemory appended to: ${memoryFile}`
+              text: `✅ Experience solidifed to memory!\nLevel: ${memoryLevel}\nTags: ${tags ? tags.join(', ') : '(none)'}\nMemory appended to: ${memoryFile}`
             }
           ]
         };

--- a/src/mcp/worker-spawner.ts
+++ b/src/mcp/worker-spawner.ts
@@ -25,6 +25,7 @@ import { AcpAdapter } from "../adapters/AcpAdapter";
 import { MAX_DELEGATION_DEPTH } from "../constants";
 import { sanitizeExternalContent } from "../utils/sanitizeExternalContent";
 import { registerRole } from "../utils/resolveRoleName";
+import { loadFilteredMemory, migrateMemoryFile } from "../managers/MemoryManager";
 
 function parseFrontmatter(content: string): { frontmatter: Record<string, string>, body: string } {
     const normalized = content.replace(/\r\n/g, '\n');
@@ -912,41 +913,6 @@ function getAdapterForEngine(engine: string, sessionId?: string, model?: string,
 }
 
 /**
- * Loads project memory entries from .optimus/memory/continuous-memory.md.
- * Returns newest-first entries (body only, frontmatter stripped) up to maxChars.
- * Best-effort: returns empty string on any error.
- */
-function loadProjectMemory(workspacePath: string, maxChars: number = 4000): string {
-    const memoryFile = path.join(workspacePath, '.optimus', 'memory', 'continuous-memory.md');
-    if (!fs.existsSync(memoryFile)) return '';
-
-    try {
-        const raw = fs.readFileSync(memoryFile, 'utf8');
-        if (!raw.trim()) return '';
-
-        // Split on YAML frontmatter delimiters to get individual entries
-        // Each entry starts with ---\nid: ... \n---\n<body>
-        const entries = raw.split(/(?=^---\nid:)/m).filter(e => e.trim());
-
-        // Reverse for newest-first
-        entries.reverse();
-
-        let content = '';
-        for (const entry of entries) {
-            // Strip YAML frontmatter, keep only body text
-            const body = entry.replace(/^---[\s\S]*?---\n?/m, '').trim();
-            if (!body) continue;
-            if (content.length + body.length + 4 > maxChars) break;
-            content = body + '\n\n' + content; // Prepend to restore chronological order
-        }
-
-        return content.trim();
-    } catch (e) {
-        return ''; // Silent fail — memory injection is best-effort
-    }
-}
-
-/**
  * Executes a single task delegation synchronously.
  */
 export async function delegateTaskSingle(roleArg: string, taskPath: string, outputPath: string, _fallbackSessionId: string, workspacePath: string, contextFiles?: string[], masterInfo?: MasterRoleInfo, parentDepth?: number, parentIssueNumber?: number, autoIssueNumber?: number, agentId?: string): Promise<string> {
@@ -1184,7 +1150,9 @@ export async function delegateTaskSingle(roleArg: string, taskPath: string, outp
     }
 
     // Load project memory for injection (after persona, before task)
-    const memoryContent = loadProjectMemory(workspacePath);
+    const memoryFile = path.join(workspacePath, '.optimus', 'memory', 'continuous-memory.md');
+    migrateMemoryFile(memoryFile);
+    const memoryContent = loadFilteredMemory(workspacePath, role);
     const memorySection = memoryContent
         ? `\n\n--- START PROJECT MEMORY ---\nThe following are verified lessons and decisions from this project's history.\nApply them to avoid repeating past mistakes.\n\n${memoryContent}\n--- END PROJECT MEMORY ---`
         : '';
@@ -1267,7 +1235,8 @@ Please provide your complete execution result below.`;
         }
 
         const extraEnv: Record<string, string> = {
-            OPTIMUS_DELEGATION_DEPTH: String(childDepth)
+            OPTIMUS_DELEGATION_DEPTH: String(childDepth),
+            OPTIMUS_CURRENT_ROLE: role,
         };
         if (parentIssueNumber !== undefined) {
             extraEnv.OPTIMUS_PARENT_ISSUE = String(parentIssueNumber);


### PR DESCRIPTION
## Summary

Implements the Multi-Level Memory System for Optimus (Fixes #375).

### Changes

**New file: `src/managers/MemoryManager.ts`**
- YAML frontmatter parser (`parseMemoryEntries`) with robust paired-delimiter detection
- Relevance scoring (`scoreEntry`): +3 for role match, +2 for 7-day recency, +1 for 30-day recency
- Tiered greedy-fill loader (`loadFilteredMemory`): reserves ~2000 chars for project-level entries, ~6000 for role-specific, remainder for all others; default 16000 char budget
- Legacy migration (`migrateMemoryFile`): wraps unstructured text in YAML frontmatter blocks with atomic write and `.migrated` marker
- Entry builder (`buildMemoryEntry`) and path resolver (`getMemoryFilePath`) with lexical + `realpathSync` security validation

**Modified: `src/mcp/mcp-server.ts`**
- Added `level` parameter (`"project" | "role"`) to `append_memory` tool schema
- Updated handler to route writes to project or role-specific memory files
- Uses `buildMemoryEntry()` and `getMemoryFilePath()` from MemoryManager
- Returns clear error when `level: "role"` is used without `OPTIMUS_CURRENT_ROLE`

**Modified: `src/mcp/worker-spawner.ts`**
- Added `OPTIMUS_CURRENT_ROLE` env var to delegated worker `extraEnv`
- Replaced `loadProjectMemory()` with `migrateMemoryFile()` + `loadFilteredMemory()` from MemoryManager
- Removed old `loadProjectMemory()` function (lines 919-947)

### Backward Compatibility
- Existing `append_memory` calls without `level` default to `"project"` — no breaking change
- Existing memory entries in `continuous-memory.md` are parsed correctly by the new parser
- Legacy unstructured text is auto-wrapped on first load via migration

### Build Verification
- `npm run build` passes with zero TypeScript errors

---
_🤖 Created by `senior-full-stack-builder` via Optimus Spartan Swarm_