### PR TITLE
fix: remove prepare hook to prevent npx ECOMPROMISED on npm v11

### DIFF
--- a/optimus-plugin/package.json
+++ b/optimus-plugin/package.json
@@ -11,8 +11,7 @@
     "build": "node esbuild.plugin.js",
     "build:production": "node esbuild.plugin.js --production",
     "prepublishOnly": "npm run build:production",
-    "postinstall": "node scripts/postinstall.js",
-    "prepare": "npm run build:production"
+    "postinstall": "node scripts/postinstall.js"
   },
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
-    "prepare": "cd optimus-plugin && npm install && npm run build:production"
+    "build": "cd optimus-plugin && npm install && npm run build:production"
   },
   "devDependencies": {
     "@types/marked": "^5.0.2",


### PR DESCRIPTION
## Summary

Fixes #471 — `npx -y github:cloga/optimus-code init/upgrade` fails with `ECOMPROMISED` / Lock compromised on npm v11 + Node v24.

### Root Cause

The `prepare` lifecycle hook on both `package.json` (root) and `optimus-plugin/package.json` triggered two rounds of `npm install` + `esbuild` bundling during every install. This far exceeded npx's lock timeout on npm v11 + Node v24.

Cascade:
1. Root `prepare`: `cd optimus-plugin && npm install && npm run build:production`
2. Plugin `prepare`: `npm run build:production` (triggered again by nested install)

### Fix

- **Root `package.json`**: Renamed `prepare` → `build`. Developers who need to rebuild run `npm run build` explicitly.
- **`optimus-plugin/package.json`**: Removed `prepare` script entirely. `prepublishOnly` already handles build-before-publish.

`dist/mcp-server.js` is pre-committed to git, so no build is needed during `npx` installs.

## What Was Not Changed

- `postinstall` in `optimus-plugin` (just prints guidance message, no build)
- `prepublishOnly` in `optimus-plugin` (still auto-builds before `npm publish`)
- Dev `npm run build` still works for local rebuilds

## Test Plan

- [ ] `npx -y github:cloga/optimus-code init` — no build triggered, completes quickly
- [ ] `npx -y github:cloga/optimus-code upgrade` — no build triggered, completes quickly
- [ ] `optimus serve` — reads pre-built `dist/mcp-server.js` successfully
- [ ] `npm run build` (dev rebuild) — still works
- [ ] `npm publish` (release) — `prepublishOnly` still fires