### PR TITLE
[Optimus] docs: make runtime guidance agent-friendly

### DIFF
--- a/optimus-plugin/scaffold/config/system-instructions.md
+++ b/optimus-plugin/scaffold/config/system-instructions.md
@@ -9,6 +9,15 @@
 ## Issue First Protocol
 Before any work begins, a GitHub Issue must be created to acquire an `#ID`. All local task files (`.optimus/tasks/`) must be bound to this ID.
 
+## Runtime Routing Protocol
+Optimus currently treats the runtime as a **per-user multi-workspace HTTP daemon**, not a repo-local singleton bound to the current checkout.
+
+Agents MUST internalize these rules before using runtime-backed flows:
+- Treat `workspace_path` as the routing key for run creation and any body-driven runtime request.
+- Treat `X-Optimus-Workspace` as the routing key for status and stream lookups when the transport expects headers.
+- Do NOT assume the daemon process identity is the current repository root; workspace is request-scoped.
+- Do NOT assume named pipes or WebSockets exist. The current stable runtime slice is the HTTP daemon model unless a future instruction explicitly says otherwise.
+
 ## Artifact Isolation
 ALL generated reports, tasks, and memory artifacts MUST be saved inside `.optimus/` subdirectories. Never write loose files to the repository root.
 

--- a/optimus-plugin/scaffold/instructions/default.md
+++ b/optimus-plugin/scaffold/instructions/default.md
@@ -26,5 +26,12 @@ start with `optimus_orchestrate`. Use `delegate_task_async` or `dispatch_plan_as
 - "Create a GitHub Issue for [task] and then use delegate_task_async for the implementation worker"
 - "Dispatch a council review for this architecture proposal"
 
+### Runtime Model
+- Optimus currently uses a **per-user multi-workspace HTTP daemon** for runtime-backed agent flows.
+- Always carry `workspace_path` on run-creation and other body-driven runtime requests.
+- Use `X-Optimus-Workspace` for status or stream lookups when the transport expects headers.
+- Do not assume the daemon is bound to the current repo root; workspace is request-scoped.
+- Do not assume named pipes or WebSockets are available unless a newer instruction explicitly says so.
+
 Full protocol: `.optimus/config/system-instructions.md`
 <!-- /optimus-instructions -->

--- a/optimus-plugin/skills/master-onboarding/SKILL.md
+++ b/optimus-plugin/skills/master-onboarding/SKILL.md
@@ -17,6 +17,15 @@ This loads the user's cross-project preferences and ensures parity with sub-agen
 
 Read `.optimus/config/system-instructions.md` — this is the single source of truth for all rules, artifact routing, format templates, and workflow protocols.
 
+## Step 1.5: Internalize the Runtime Model
+
+Before you use any runtime-backed flow, remember the current architecture:
+- Optimus uses a **per-user multi-workspace HTTP daemon**.
+- `workspace_path` is the routing key for run creation and other body-driven runtime requests.
+- `X-Optimus-Workspace` is the routing key for status/stream lookups when the transport uses headers.
+- Workspace is **request scope**, not the daemon's process identity.
+- Named pipes and WebSockets are future evolution options, not the default assumption for today's runtime.
+
 ## Step 2: Inspect Your Team
 
 Call `roster_check` with your `workspace_path` to see:


### PR DESCRIPTION
Fixes #610

## Summary
- add explicit runtime routing protocol to shipped system instructions
- add onboarding guidance for the per-user multi-workspace HTTP daemon model
- add default scaffold prompt guidance for `workspace_path` and `X-Optimus-Workspace` expectations

## Expected vs Actual
- Expected build result: `npm run build` succeeds because these changes only touch shipped markdown instruction assets
- Expected files in diff: `optimus-plugin/scaffold/config/system-instructions.md`, `optimus-plugin/scaffold/instructions/default.md`, `optimus-plugin/skills/master-onboarding/SKILL.md`
- Expected scope boundary: no source runtime files, tests, or dist bundles should change
- Actual: matched expectations; build succeeded and the diff is limited to the three instruction files above.

---
_🤖 Created by `master-agent` via Optimus Spartan Swarm_